### PR TITLE
Remove confusing exec dir message

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
@@ -405,8 +405,10 @@ abstract class ExecutionService implements BEExecutionService {
         File roddyBundledFilesDirectory = Roddy.getBundledFilesDirectory()
 
         provider.checkDirectories([executionBaseDirectory, executionDirectory, temporaryDirectory, lockFilesDirectory], context, true)
-        logger.always("Creating the following execution directory to store information about this process:")
-        logger.always("\t${executionDirectory.getAbsolutePath()}")
+        if(context.executionContextLevel.isOrWasAllowedToSubmitJobs){
+            logger.always("Creating the following execution directory to store information about this process:")
+            logger.always("\t${executionDirectory.getAbsolutePath()}")
+        }
 
         Configuration cfg = context.getConfiguration()
         def configurationValues = cfg.getConfigurationValues()


### PR DESCRIPTION
As of one update, Roddy will create more than one execution directory
(e.g. to have all scripts on the target system, when using a tool to
load files). This directory will always be removed and the message
telling the user, that the directory was created, is unnecessary.
Therefore, disable the message, if the context is not allowed to submit
jobs.