### PR TITLE
Improve FileGroup usability

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
@@ -9,8 +9,11 @@ package de.dkfz.roddy.knowledge.files;
 import de.dkfz.roddy.config.ConfigurationError;
 import de.dkfz.roddy.core.ExecutionContext;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 
 /**
  * Filegroups group multiple files into one group. I.e. BamFiles can be grouped
@@ -18,7 +21,7 @@ import java.util.List;
  *
  * @author michael
  */
-public abstract class FileGroup<F extends BaseFile> extends FileObject {
+public abstract class FileGroup<F extends BaseFile> extends FileObject implements Iterable<F> {
 
     // In some cases a group has another group as a parent.
     protected FileGroup parentGroup;
@@ -30,6 +33,21 @@ public abstract class FileGroup<F extends BaseFile> extends FileObject {
         if (files != null) {
             addFiles(files);
         }
+    }
+
+    @Override
+    public Iterator<F> iterator() {
+        return filesInGroup.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super F> action) {
+        filesInGroup.forEach(action);
+    }
+
+    @Override
+    public Spliterator<F> spliterator() {
+        return filesInGroup.spliterator();
     }
 
     /**
@@ -49,6 +67,22 @@ public abstract class FileGroup<F extends BaseFile> extends FileObject {
         } else {
             throw new RuntimeException("Cannot call getExecutionContext if FileGroup has no files in it.");
         }
+    }
+
+    public final void add(F file) {
+        addFile(file);
+    }
+
+    public final void leftShift(F file) {
+        addFile(file);
+    }
+
+    public final void plus(F file) {
+        addFile(file);
+    }
+
+    public final void plus(FileGroup<F> filegroup) {
+        addFiles(filegroup.filesInGroup);
     }
 
     public final void addFile(F file) {


### PR DESCRIPTION
Implement the Iterable interface and thus allow operations like:
for in
.forEach
for file groups. The methods effectively use the iterator methods of the
contained file list.

Also allow the groovy methods:
+
+=
<<
on FileGroups