### PR TITLE
Improve FileGroup usability

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
@@ -9,8 +9,11 @@ package de.dkfz.roddy.knowledge.files;
 import de.dkfz.roddy.config.ConfigurationError;
 import de.dkfz.roddy.core.ExecutionContext;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 
 /**
  * Filegroups group multiple files into one group. I.e. BamFiles can be grouped
@@ -18,7 +21,7 @@ import java.util.List;
  *
  * @author michael
  */
-public abstract class FileGroup<F extends BaseFile> extends FileObject {
+public abstract class FileGroup<F extends BaseFile> extends FileObject implements Iterable<F> {
 
     // In some cases a group has another group as a parent.
     protected FileGroup parentGroup;
@@ -30,6 +33,21 @@ public abstract class FileGroup<F extends BaseFile> extends FileObject {
         if (files != null) {
             addFiles(files);
         }
+    }
+
+    @Override
+    public Iterator<F> iterator() {
+        return filesInGroup.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super F> action) {
+        filesInGroup.forEach(action);
+    }
+
+    @Override
+    public Spliterator<F> spliterator() {
+        return filesInGroup.spliterator();
     }
 
     /**
@@ -49,6 +67,22 @@ public abstract class FileGroup<F extends BaseFile> extends FileObject {
         } else {
             throw new RuntimeException("Cannot call getExecutionContext if FileGroup has no files in it.");
         }
+    }
+
+    public final void add(F file) {
+        addFile(file);
+    }
+
+    public final void leftShift(F file) {
+        addFile(file);
+    }
+
+    public final void plus(F file) {
+        addFile(file);
+    }
+
+    public final void plus(FileGroup<F> filegroup) {
+        addFiles(filegroup.filesInGroup);
     }
 
     public final void addFile(F file) {

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
@@ -45,11 +45,6 @@ public abstract class FileGroup<F extends BaseFile> extends FileObject implement
         filesInGroup.forEach(action);
     }
 
-    @Override
-    public Spliterator<F> spliterator() {
-        return filesInGroup.spliterator();
-    }
-
     /**
      * Calls runDefaultOperations on the contained files.
      */
@@ -77,12 +72,14 @@ public abstract class FileGroup<F extends BaseFile> extends FileObject implement
         addFile(file);
     }
 
-    public final void plus(F file) {
+    public final FileGroup<F> plus(F file) {
         addFile(file);
+        return this;
     }
 
-    public final void plus(FileGroup<F> filegroup) {
+    public final FileGroup<F> plus(FileGroup<F> filegroup) {
         addFiles(filegroup.filesInGroup);
+        return this;
     }
 
     public final void addFile(F file) {

--- a/RoddyCore/test/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
@@ -1,0 +1,145 @@
+package de.dkfz.roddy.knowledge.files
+
+import de.dkfz.roddy.core.ExecutionContext
+import de.dkfz.roddy.core.MockupExecutionContextBuilder
+import de.dkfz.roddy.core.RuntimeService
+import groovy.transform.CompileStatic
+import org.junit.BeforeClass
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+@CompileStatic
+class FileGroupTest {
+
+    static ExecutionContext mockupContext = MockupExecutionContextBuilder.createSimpleContext(FileGroupTest.class.name)
+    static List<BaseFile> listOfFiles = [
+            createFileObject("a"),
+            createFileObject("b"),
+            createFileObject("c"),
+            createFileObject("d"),
+    ]
+
+    static BaseFile createFileObject(String suffix) {
+        BaseFile.getSourceFile(mockupContext, "/tmp/somefile_${suffix}")
+    }
+
+    FileGroup<BaseFile> getTestFileGroup() {
+        return new GenericFileGroup<BaseFile>(listOfFiles)
+    }
+
+    @Test
+    void testGetFileGroup() {
+        def fg = getTestFileGroup()
+        assert fg.size() == 4
+        assert fg[0].path ==  new File("/tmp/somefile_a")
+        assert fg[1].path ==  new File("/tmp/somefile_b")
+        assert fg[2].path ==  new File("/tmp/somefile_c")
+        assert fg[3].path ==  new File("/tmp/somefile_d")
+    }
+
+    @Test
+    void testGroovyIterator() {
+        int i = 0
+        getTestFileGroup().each {
+            assert it == listOfFiles[i]
+            i++
+        }
+    }
+
+    @Test
+    void testJavaForIn() {
+        int i = 0
+        for (BaseFile bf : getTestFileGroup()) {
+            assert bf == listOfFiles[i]
+            i++
+        }
+    }
+
+    @Test
+    void testForEach() {
+        getTestFileGroup().forEach {
+            assert it instanceof BaseFile
+        }
+    }
+
+    @Test
+    void testAdd() {
+        FileGroup fg = getTestFileGroup()
+        BaseFile file = createFileObject("e")
+        fg.add(file)
+        assert file.fileGroups.size() == 1
+        assert file.fileGroups[0] == fg
+        assert fg.size() == 5
+    }
+
+    @Test
+    void testLeftShiftOperator() {
+        FileGroup fg = getTestFileGroup()
+        BaseFile file = createFileObject("e")
+        fg << file
+        assert file.fileGroups.size() == 1
+        assert file.fileGroups[0] == fg
+        assert fg.size() == 5    }
+
+    @Test
+    void testPlusOperator() {
+        FileGroup fg = getTestFileGroup()
+        BaseFile file = createFileObject("e")
+        fg += file
+        assert file.fileGroups.size() == 1
+        assert file.fileGroups[0] == fg
+        assert fg.size() == 5
+    }
+
+    @Test
+    void testAddPlusWithAnotherFileGroup() {
+        FileGroup fg1 = getTestFileGroup()
+        FileGroup fg2 = getTestFileGroup()
+        fg1 += fg2
+        assert fg1.size() == 8
+        assert fg1[4] == fg2[0]
+        assert fg1[5] == fg2[1]
+        assert fg1[6] == fg2[2]
+        assert fg1[7] == fg2[3]
+    }
+
+    @Test
+    void testAddFile() {
+        FileGroup fg = getTestFileGroup()
+        BaseFile file = createFileObject("e")
+        fg.add(file)
+        assert file.fileGroups.size() == 1
+        assert file.fileGroups[0] == fg
+        assert fg.size() == 5
+    }
+
+    @Test
+    void testAddFiles() {
+        FileGroup fg = getTestFileGroup()
+        BaseFile file1 = createFileObject("e")
+        BaseFile file2 = createFileObject("f")
+        fg.addFiles([file1, file2])
+        assert fg.size() == 6
+    }
+
+    @Test
+    void testGetAt() {
+        FileGroup fg = getTestFileGroup()
+        assert fg[0].path == new File("/tmp/somefile_a")
+        assert fg[3].path == new File("/tmp/somefile_d")
+    }
+
+    @Test
+    void testGet() {
+        FileGroup fg = getTestFileGroup()
+        assert fg[0].path == new File("/tmp/somefile_a")
+        assert fg[3].path == new File("/tmp/somefile_d")
+    }
+
+    @Test
+    void testGetFilesInGroup() {
+        FileGroup fg = getTestFileGroup()
+        assert fg.filesInGroup == listOfFiles
+    }
+}


### PR DESCRIPTION
Implement the Iterable interface and thus allow operations like:
for in
.forEach
for file groups. The methods effectively use the iterator methods of the
contained file list.

Also allow the groovy methods:
+
+=
<<
on FileGroups