### PR TITLE
Add roddy install and add err check

### DIFF
--- a/dist/bin/develop/helperScripts/compileRoddyBinary.sh
+++ b/dist/bin/develop/helperScripts/compileRoddyBinary.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-echo "Increasing build number and date to"
-#$GROOVY_BINARY ${SCRIPTS_DIR}/IncreaseAndSetBuildVersion.groovy RoddyCore/buildversion.txt RoddyCore/src/de/dkfz/roddy/Constants.java
-echo "  "$(head -n 1 RoddyCore/buildversion.txt).$(tail -n 1 RoddyCore/buildversion.txt)
-
 echo "Storing buildinfo for the new Roddy jar file"
 echo JDKVersion=$JDK_VERSION > dist/bin/develop/buildinfo.txt
 echo GroovyVersion=$GROOVY_VERSION >> dist/bin/develop/buildinfo.txt


### PR DESCRIPTION
roddy install [tagid] will check your local repository for the existence
of a specific Roddy tag. If it exists, a temporary directory will be
created, Roddy will be cloned to it and the requested tag will be
compiled. Finally it will be copied to your local installation. Nothing
is changed in your repository!

Add check for compileplugin, if a Roddy jar exists. If not, abort.