### PR TITLE
Fix for Configuration value replacement

### DIFF
--- a/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/LSInputImpl.java
+++ b/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/LSInputImpl.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2015 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package com.stackoverflow.questions.xmlvalidation;

--- a/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/ResourceResolver.java
+++ b/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/ResourceResolver.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package com.stackoverflow.questions.xmlvalidation;

--- a/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;
@@ -40,7 +40,7 @@ enum AvailableFeatureToggles {
     ////////////////////////
     */
     @Deprecated
-    ForbidSubmissionOnRunning(false),
+    ForbidSubmissionOnRunning(true),
 
     @Deprecated
     BreakSubmissionOnError(false),

--- a/RoddyCore/src/de/dkfz/roddy/Constants.java
+++ b/RoddyCore/src/de/dkfz/roddy/Constants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;
@@ -41,6 +41,7 @@ public class Constants {
     public static final String APP_PROPERTY_SCRATCH_BASE_DIRECTORY = "scratchBaseDirectory";
     public static final String APP_PROPERTY_JOB_MANAGER_PASS_ENVIRONMENT = "jobManagerPassEnvironment";
     public static final String APP_PROPERTY_JOB_MANAGER_HOLDJOBS_ON_SUBMISSION = "jobManagerHoldJobsOnSubmission";
+    public static final String APP_PROPERTY_JOB_MANAGER_UPDATE_INTERVAL = "jobManagerUpdateInterval";
     public static final String APP_PROPERTY_BASE_ENVIRONMENT_SCRIPT = "baseEnvironmentScript";
 
     /////////////////////////
@@ -50,8 +51,6 @@ public class Constants {
     public static final String ERR_MSG_ONLY_ONE_JOB_ALLOWED = "A job object is not allowed to run several times.";
     public static final String ERR_MSG_WRONG_PARAMETER_COUNT = "You did not provide proper parameters, args.length = ";
     public static final String ERR_MSG_NO_APPLICATION_PROPERTY_FILE = "Configuration does not exist. Cannot start application.";
-
-//    public static final String APP_EXITCODE_
 
     /////////////////////////
     // Environment settings

--- a/RoddyCore/src/de/dkfz/roddy/Constants.java
+++ b/RoddyCore/src/de/dkfz/roddy/Constants.java
@@ -34,7 +34,6 @@ public class Constants {
     public static final String APP_PROPERTY_CONFIGURATION_DIRECTORIES = "configurationDirectories";
     public static final String APP_PROPERTY_PLUGIN_DIRECTORIES = "pluginDirectories";
     public static final String APP_PROPERTIES_FILENAME = "applicationProperties.ini";
-    public static final String APP_PROPERTY_APPLICATION_DEBUG_TAG_NOJOBSUBMISSION = "NOJOBSUBMISSION";
     public static final String APP_PROPERTY_NET_USEPROXY = "netUseProxy";
     public static final String APP_PROPERTY_NET_PROXY_ADDRESS = "netProxyAddress";
     public static final String APP_PROPERTY_NET_PROXY_USR = "netProxyUser";
@@ -50,20 +49,12 @@ public class Constants {
 
     public static final String ERR_MSG_ONLY_ONE_JOB_ALLOWED = "A job object is not allowed to run several times.";
     public static final String ERR_MSG_WRONG_PARAMETER_COUNT = "You did not provide proper parameters, args.length = ";
-    public static final String ERR_MSG_NO_APPLICATION_PROPERTY_FILE = "Configuration does not exist. Cannot start application.";
 
     /////////////////////////
     // Environment settings
     /////////////////////////
 
-    public static final String ENV_LINESEPARATOR = System.getProperty("line.separator");
-
-    /////////////////////////
-    // Roddy tools
-    /////////////////////////
-
-    public static final String TOOLID_CREATE_LOCKFILES = "createLockFiles";
-    public static final String TOOLID_STREAM_BUFFER = "streamBuffer";
+    public static final String ENV_LINESEPARATOR = SystemProperties.getLineSeparator();
 
     /////////////////////////
     // Other constants
@@ -72,6 +63,9 @@ public class Constants {
     public static final String UNKNOWN_USER = "UNKNOWN";
     public static final String UNKNOWN = "UNKNOWN";
     public static final String NO_VALUE = "<NO_VALUE>";
+    public static final String USERNAME = "USERNAME";
+    public static final String USERGROUP = "USERGROUP";
+    public static final String USERHOME = "USERHOME";
     public static final String DEFAULT = "default";
 
     public static final String RODDY_PARENT_JOBS = "RODDY_PARENT_JOBS";
@@ -81,8 +75,11 @@ public class Constants {
     public static final String PARAMETER_FILE_SUFFIX = ".parameters";
     public static final String PROJECT_NAME = "projectName";
     public static final String DATASET = "dataSet";
+    public static final String DATASET_HR = "dataset";
     public static final String DATASET_CAP = "DATASET";
+    @Deprecated
     public static final String PID_CAP = "PID";
+    @Deprecated
     public static final String PID = "pid";
 
     /////////////////////////

--- a/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
+
+package de.dkfz.roddy
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+enum ExitReasons {
+
+    wrongStartupLocation(255, "Wrong execution directory. Change to directory with roddy.sh before execution."),
+    groovyServError(254, "SystemExitException throw by GroovyServ, will exit now."),
+    malformedCommandLine(253, "Command line was malformed."),
+    unfulfilledRequirements(252, "Execution requirements unfulfilled."),
+    unparseableStartupOptions(251, "Startup options could not be parsed."),
+    unknownFeatureToggleFile(250, "Cannot find requested feature toggle file."),
+    unknownFeatureToggle(249, "Feature toggle is not known."),
+    unknownProxyProblem(248, "Unknown problem with proxy setup."),
+    scratchDirNotConfigured(247, Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY + " is not defined."),
+    wrongJobManagerClass(246, "Wrong job manager class."),
+    appPropertiesFileNotFound(245, "Application properties file not found or loadable."),
+    analysisNotLoadable(244, "Could not load analysis."),
+    severeConfigurationErrors(243, "Severe configuration errors occurred."),
+    unhandledException(242, "Unhandled exception."),
+    unknownSSHHost(241, "SSH remote host could not be reached."),
+    invalidSSHConfig(240, "SSH setup is not valid."),
+    fatalSSHError(239, "Fatal error during SSH setup."),
+    aJobHadAnError(238, "At least one job exited with an error."),
+    waitForJobsFailedWithAnUnknownError(237, "Roddy.waitForJobs() failed with an unknown exception."),
+
+    wrongExitCodeUsed(100, "Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255].")
+
+    final String message
+
+    final int code
+
+    ExitReasons(int code, String message) {
+        this.message = message
+        this.code = code
+    }
+}

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -226,7 +226,7 @@ public class Roddy {
             // we check for this particular exception by using its simple class name!
             if (!e.getClass().getName().endsWith("SystemExitException"))
                 e.printStackTrace();
-            exit(ExitReasons.groovyServError);
+            exitWithMessage(ExitReasons.groovyServError);
         }
     }
 
@@ -429,7 +429,7 @@ public class Roddy {
                 }
             }
         } catch (RuntimeException e) {
-            exit(ExitReasons.unparseableStartupOptions);
+            exitWithMessage(ExitReasons.unparseableStartupOptions);
         }
     }
 
@@ -439,7 +439,7 @@ public class Roddy {
             toggleIni = new File(commandLineCall.getOptionValue(RoddyStartupOptions.usefeaturetoggleconfig));
             logger.postSometimesInfo("Trying to load alternative feature toggles file: " + toggleIni);
             if (toggleIni == null || !toggleIni.exists()) {
-                exit(ExitReasons.unknownFeatureToggleFile);
+                exitWithMessage(ExitReasons.unknownFeatureToggleFile);
             }
 
         } else {
@@ -779,7 +779,7 @@ public class Roddy {
                 }
             }
         } catch (Exception ex) {
-            exit(ExitReasons.waitForJobsFailedWithAnUnknownError);
+            exitWithMessage(ExitReasons.waitForJobsFailedWithAnUnknownError);
         }
         return 0;
     }
@@ -795,7 +795,7 @@ public class Roddy {
         System.exit(ecode <= 255 ? ecode : ExitReasons.wrongExitCodeUsed.getCode()); //Exit codes should be in range from 0 .. 255
     }
 
-    public static void exit(ExitReasons reason) {
+    public static void exitWithMessage(ExitReasons reason) {
         logger.severe(reason.getMessage());
         exit(reason.getCode());
     }

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;
@@ -26,7 +26,10 @@ import de.dkfz.roddy.execution.jobs.BatchEuphoriaJobManager;
 import de.dkfz.roddy.execution.jobs.JobManagerOptions;
 import de.dkfz.roddy.execution.jobs.direct.synchronousexecution.DirectSynchronousExecutionJobManager;
 import de.dkfz.roddy.plugins.LibrariesFactory;
-import de.dkfz.roddy.tools.*;
+import de.dkfz.roddy.tools.AppConfig;
+import de.dkfz.roddy.tools.LoggerWrapper;
+import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
+import de.dkfz.roddy.tools.RoddyIOHelperMethods;
 import groovy.transform.CompileStatic;
 
 import java.io.File;
@@ -37,6 +40,7 @@ import java.net.InetSocketAddress;
 import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.*;
 
 import static de.dkfz.roddy.RunMode.CLI;
@@ -201,7 +205,7 @@ public class Roddy {
             if (list == null || list.length != 1) {
                 System.out.println("You must call roddy from the right location! (Base roddy folder where roddy.sh resides). You used: '" +
                         applicationDirectory + "'");
-                System.exit(255);
+                System.exit(ExitReasons.wrongStartupLocation.getCode());
             }
 
             if (args.length == 0) {
@@ -222,7 +226,7 @@ public class Roddy {
             // we check for this particular exception by using its simple class name!
             if (!e.getClass().getName().endsWith("SystemExitException"))
                 e.printStackTrace();
-            exit(1);
+            exit(ExitReasons.groovyServError);
         }
     }
 
@@ -248,7 +252,7 @@ public class Roddy {
         CommandLineCall clc = new CommandLineCall(list);
         commandLineCall = clc;
         if (clc.isMalformed())
-            exit(1);
+            exit(ExitReasons.malformedCommandLine.getCode());
 
         // Initialize the logger with an initial setup. At this point we don't know about things like the logger settings
         // or the used app ini file. However, all the following methods rely on an existing valid logger setup.
@@ -258,7 +262,7 @@ public class Roddy {
 
         time("initial checks");
         if (!roddyExecutionRequirementsFulfilled())
-            exit(1);
+            exit(ExitReasons.unfulfilledRequirements.getCode());
 
         time("ftoggleini");
         initializeFeatureToggles();
@@ -281,7 +285,7 @@ public class Roddy {
         }
 
         if (!jobExecutionRequirementsFulfilled())
-            exit(1);
+            exit(ExitReasons.unfulfilledRequirements.getCode());
 
         time("initserv");
         parseRoddyStartupModeAndRun(clc);
@@ -425,8 +429,7 @@ public class Roddy {
                 }
             }
         } catch (RuntimeException e) {
-            logger.severe("Parsing startup options failed.");
-            exit(1);
+            exit(ExitReasons.unparseableStartupOptions);
         }
     }
 
@@ -436,8 +439,7 @@ public class Roddy {
             toggleIni = new File(commandLineCall.getOptionValue(RoddyStartupOptions.usefeaturetoggleconfig));
             logger.postSometimesInfo("Trying to load alternative feature toggles file: " + toggleIni);
             if (toggleIni == null || !toggleIni.exists()) {
-                logger.postAlwaysInfo("Cannot find requested toggle file.");
-                exit(1);
+                exit(ExitReasons.unknownFeatureToggleFile);
             }
 
         } else {
@@ -465,7 +467,7 @@ public class Roddy {
             String toggleNames = RoddyIOHelperMethods.joinArray(AvailableFeatureToggles.values(), "\n\t");
             logger.severe("Available toggle values are:\n\t" + toggleNames);
             if (isStrictModeEnabled())
-                exit(1);
+                exit(ExitReasons.unknownFeatureToggle.getCode());
         }
     }
 
@@ -571,7 +573,7 @@ public class Roddy {
                 l = ProxySelector.getDefault().select(new URI("http://codemirror.net"));
             } catch (URISyntaxException e) {
                 e.printStackTrace();
-                System.exit(1);
+                System.exit(ExitReasons.unknownProxyProblem.getCode());
             }
 
             if (l != null) {
@@ -618,8 +620,10 @@ public class Roddy {
         }
     }
 
-    /** Copy the scratchBaseDirectory value from the applicationProperties.ini into the configuration. Set the default value for RODDY_SCRATCH
-     *  to $scratchBaseDirectory/$RODDY_JOBID.
+    /**
+     * Copy the scratchBaseDirectory value from the applicationProperties.ini into the configuration. Set the default value for RODDY_SCRATCH
+     * to $scratchBaseDirectory/$RODDY_JOBID.
+     *
      * @return
      */
     private static void setScratchDirectory(RecursiveOverridableMapContainerForConfigurationValues configurationValues) {
@@ -631,7 +635,7 @@ public class Roddy {
                 propertyFilePath = Roddy.getPropertiesFilePath();
                 System.err.println(Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY +
                         " is not defined. Please add it to your application properties file: '" + propertyFilePath + "'");
-                System.exit(1);
+                System.exit(ExitReasons.scratchDirNotConfigured.getCode());
             } catch (FileNotFoundException e) {
                 // The file must have existed, because we are accessing the values in it.
                 scratchBaseDir = System.getenv("CURRENT_PWD");
@@ -642,7 +646,7 @@ public class Roddy {
 
         }
         configurationValues.add(new ConfigurationValue(Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY, scratchBaseDir));
-        String scratchDir = new File ("$" + Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY,
+        String scratchDir = new File("$" + Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY,
                 "$" + ConfigurationConstants.CVALUE_PLACEHOLDER_RODDY_JOBID_RAW).toString();
         configurationValues.add(new ConfigurationValue(CVALUE_PLACEHOLDER_RODDY_SCRATCH_RAW, scratchDir));
     }
@@ -708,7 +712,7 @@ public class Roddy {
                 available.append("\n\t" + acs.getClassName());
             }
             logger.severe("Could not find job manager class: " + jobManagerClassID + ", available are: " + available.toString() + "\nPlease set the jobManagerClass entry in your application ini file: " + getPropertiesFilePath().getAbsolutePath() + "");
-            exit(1);
+            exit(ExitReasons.wrongJobManagerClass.getCode());
         }
 
         /** Get the constructor which comes with no parameters */
@@ -716,10 +720,19 @@ public class Roddy {
         jobManager = (BatchEuphoriaJobManager) first.newInstance(ExecutionService.getInstance()
                 , JobManagerOptions.create()
                         .setCreateDaemon(true)
+                        .setUpdateInterval(Duration.ofSeconds(RoddyConversionHelperMethods.toInt(applicationProperties.getOrSetApplicationProperty(Constants.APP_PROPERTY_JOB_MANAGER_UPDATE_INTERVAL, "300", "integer"))))
                         .setPassEnvironment(applicationProperties.getOrSetBooleanApplicationProperty(Constants.APP_PROPERTY_JOB_MANAGER_PASS_ENVIRONMENT, false))
                         .setTrackOnlyStartedJobs(trackOnlyStartedJobs)
                         .setHoldJobIsEnabled(applicationProperties.getOrSetBooleanApplicationProperty(Constants.APP_PROPERTY_JOB_MANAGER_HOLDJOBS_ON_SUBMISSION, true))
                         .setUserIdForJobQueries(FileSystemAccessProvider.getInstance().callWhoAmI()).build());
+        jobManager.addUpdateDaemonListener((job, state) -> {
+            if (state.isSuccessful()) {
+                // Message for started jobs are also printed with println
+                System.out.println(String.format("  Job %s finished successfully.", job.getJobID()));
+            } else {
+                System.out.println(String.format("  Job %s finished with an error and state %s.", job.getJobID(), state.name()));
+            }
+        });
     }
 
     private static BatchEuphoriaJobManager jobManager;
@@ -750,8 +763,7 @@ public class Roddy {
             if (jobManager.executesWithoutJobSystem() && waitForJobsToFinish) {
                 exitCode = waitForJobs();
             } else {
-                // TODO: #167 (https://github.com/eilslabs/Roddy/issues/167)
-                exit(0);
+                exitCode = 0;
             }
         }
         exit(exitCode);
@@ -759,12 +771,17 @@ public class Roddy {
 
     private static int waitForJobs() {
         try {
-            Thread.sleep(15000); //Sleep at least 15 seconds to let any job scheduler handle things...
-            return jobManager.waitForJobsToFinish();
+            if (jobManager.isDaemonAlive()) {
+                logger.always("Waiting now, until all jobs are finished.");
+                Thread.sleep(5000); //Sleep at least 5 seconds to let any job scheduler handle things...
+                if (jobManager.waitForJobsToFinish()) {
+                    return ExitReasons.aJobHadAnError.getCode();
+                }
+            }
         } catch (Exception ex) {
-            return 250;
+            exit(ExitReasons.waitForJobsFailedWithAnUnknownError);
         }
-
+        return 0;
     }
 
     public static void exit() {
@@ -773,7 +790,14 @@ public class Roddy {
 
     public static void exit(int ecode) {
         Initializable.destroyAll();
-        System.exit(ecode <= 250 ? ecode : 250); //Exit codes should be in range from 0 .. 255
+        if (jobManager != null)
+            jobManager.stopUpdateDaemon();
+        System.exit(ecode <= 255 ? ecode : ExitReasons.wrongExitCodeUsed.getCode()); //Exit codes should be in range from 0 .. 255
+    }
+
+    public static void exit(ExitReasons reason) {
+        logger.severe(reason.getMessage());
+        exit(reason.getCode());
     }
 
     public static void loadPropertiesFile() {
@@ -782,7 +806,7 @@ public class Roddy {
             file = getPropertiesFilePath();
         } catch (FileNotFoundException e) {
             logger.postAlwaysInfo("Could not load the application properties file: " + e.getMessage() + ". Roddy will exit.");
-            exit(1);
+            exit(ExitReasons.appPropertiesFileNotFound.getCode());
         }
         logger.postAlwaysInfo("Loading properties file " + file.getAbsolutePath() + ".");
 

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -102,7 +102,7 @@ public class Roddy {
     private static String baseInputDirectory;
     private static String baseOutputDirectory;
 
-    private static final File applicationDirectory = new File(System.getProperty("user.dir"));
+    private static final File applicationDirectory = new File(SystemProperties.getUserDir());
     private static final File applicationBundleDirectory = new File(applicationDirectory, "bundledFiles");
 
     private static CommandLineCall commandLineCall;
@@ -640,7 +640,7 @@ public class Roddy {
                 // The file must have existed, because we are accessing the values in it.
                 scratchBaseDir = System.getenv("CURRENT_PWD");
                 if (scratchBaseDir == null) {
-                    scratchBaseDir = System.getProperty("user.dir");
+                    scratchBaseDir = SystemProperties.getUserDir();
                 }
             }
 
@@ -834,7 +834,7 @@ public class Roddy {
      * @return
      */
     public static File getSettingsDirectory() {
-        String userHome = System.getProperty("user.home");
+        String userHome = SystemProperties.getUserHome();
         if (userHome == null) {
             throw new IllegalStateException("user.home==null");
         }

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -668,12 +668,12 @@ public class Roddy {
             configurationValues.addAll(externalConfigurationValues);
 
             if (useCustomIODirectories()) {
-                configurationValues.add(new ConfigurationValue(CFG_INPUT_BASE_DIRECTORY, Roddy.getCustomBaseInputDirectory(), "path"));
-                configurationValues.add(new ConfigurationValue(CFG_OUTPUT_BASE_DIRECTORY, Roddy.getCustomBaseOutputDirectory(), "path"));
+                configurationValues.add(new ConfigurationValue(CFG_INPUT_BASE_DIRECTORY, Roddy.getCustomBaseInputDirectory(), CVALUE_TYPE_PATH));
+                configurationValues.add(new ConfigurationValue(CFG_OUTPUT_BASE_DIRECTORY, Roddy.getCustomBaseOutputDirectory(), CVALUE_TYPE_PATH));
             }
 
             if (getUsedResourcesSize() != null) {
-                configurationValues.add(new ConfigurationValue(CFG_USED_RESOURCES_SIZE, Roddy.getUsedResourcesSize().toString(), "string"));
+                configurationValues.add(new ConfigurationValue(CFG_USED_RESOURCES_SIZE, Roddy.getUsedResourcesSize().toString(), CVALUE_TYPE_STRING));
             }
 
         }

--- a/RoddyCore/src/de/dkfz/roddy/RunMode.java
+++ b/RoddyCore/src/de/dkfz/roddy/RunMode.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;

--- a/RoddyCore/src/de/dkfz/roddy/SystemProperties.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/SystemProperties.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy
+
+import groovy.transform.CompileStatic
+
+/**
+ * Facade for different system properties to reduce code duplication and typos.
+ */
+@CompileStatic
+class SystemProperties {
+    static String getUserName() {
+        return System.properties["user.name"]
+    }
+
+    static String getUserHome() {
+        return System.properties["user.home"]
+    }
+
+    static String getUserDir() {
+        return System.properties["user.dir"]
+    }
+
+    static String getLineSeparator() {
+        return System.properties["line.separator"]
+    }
+
+    static String getJavaVersion() {
+        return System.properties["java.version"]
+    }
+
+    static String getJavaClasspath() {
+        return System.properties["java.class.path"]
+    }
+}

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client;

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/CommandLineCall.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/CommandLineCall.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient
@@ -70,7 +70,7 @@ class RoddyCLIClient {
 
     static void startMode(CommandLineCall clc) {
         //TODO Convert to CommandLineCall
-        String[] args = clc.getArguments();
+        String[] args = clc.getArguments().toArray(new String[0]);
         switch (clc.startupMode) {
             case showreadme:
                 showReadme();
@@ -277,7 +277,7 @@ class RoddyCLIClient {
         Analysis analysis = new ProjectLoader().loadAnalysisAndProject(analysisID)
         if (!analysis) {
             logger.severe("Could not load analysis ${analysisID}")
-            Roddy.exit(1)
+            Roddy.exit(ExitReasons.analysisNotLoadable.getCode())
         }
         // This check only applies for analysis configuration files.
         checkConfigurationErrorsAndMaybePrintAndFail(analysis.configuration)
@@ -295,7 +295,7 @@ class RoddyCLIClient {
             } else {
                 logger.severe("There were configuration errors and Roddy will not start. Consider using --${RoddyStartupOptions.ignoreconfigurationerrors.name()} to ignore errors.")
                 System.err.println(errorText)
-                Roddy.exit(1)
+                Roddy.exit(ExitReasons.severeConfigurationErrors.code)
             }
         }
     }

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -32,6 +32,7 @@ import de.dkfz.roddy.tools.versions.Version
 
 import static de.dkfz.roddy.StringConstants.SPLIT_COMMA
 import static de.dkfz.roddy.client.RoddyStartupModes.*
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_PATH
 
 /**
  * Command line client for roddy.
@@ -215,12 +216,12 @@ class RoddyCLIClient {
             // Fill variable, if it is missing. Log a warning.
             if (!valueInDir) {
                 logger.always("The input base directory is not set. Taking the path of the output base directory instead.")
-                analysis.configuration.configurationValues.add(new ConfigurationValue(ConfigurationConstants.CFG_INPUT_BASE_DIRECTORY, valueOutDir, "path"))
+                analysis.configuration.configurationValues.add(new ConfigurationValue(ConfigurationConstants.CFG_INPUT_BASE_DIRECTORY, valueOutDir, CVALUE_TYPE_PATH))
             }
 
             if (!valueOutDir) {
                 logger.always("The output base directory is not set. Taking the path of the input base directory instead.")
-                analysis.configuration.configurationValues.add(new ConfigurationValue(ConfigurationConstants.CFG_OUTPUT_BASE_DIRECTORY, valueInDir, "path"))
+                analysis.configuration.configurationValues.add(new ConfigurationValue(ConfigurationConstants.CFG_OUTPUT_BASE_DIRECTORY, valueInDir, CVALUE_TYPE_PATH))
             }
 
             // Now start with the input directory

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIDevClient.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIDevClient.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyDevelopmentOptionStep.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyDevelopmentOptionStep.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashColours.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashColours.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashFormatter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashFormatter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/ConsoleStringFormatter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/ConsoleStringFormatter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColorsFormatter.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColorsFormatter.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColours.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColours.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy
@@ -41,7 +41,7 @@ public class RoddyNetworkSubmissionServer {
 
         } catch (Exception ex) {
             System.out.println(ex);
-            System.exit(1);
+            System.exit(ExitReasons.unhandledException.code);
         }
 
         //Just exit without an error

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnection.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnection.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterface.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterface.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementation.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementation.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIServer.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIServer.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisImportKillSwitch.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisImportKillSwitch.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/Configuration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Configuration.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
@@ -50,10 +50,16 @@ public class ConfigurationConstants {
     public static final String CVALUE_PLACEHOLDER_RODDY_QUEUE_RAW = "RODDY_QUEUE";
     public static final String CVALUE_PLACEHOLDER_RODDY_SCRATCH_RAW = "RODDY_SCRATCH";
     public static final String CVALUE_DEFAULT_SCRATCH_DIR = "defaultScratchDir";
+    public static final String CVALUE_TYPE = "cvalueType";
     public static final String CVALUE_TYPE_BASH_ARRAY = "bashArray";
     public static final String CVALUE_TYPE_PATH = "path";
     public static final String CVALUE_TYPE_STRING = "string";
     public static final String CVALUE_TYPE_BOOLEAN = "boolean";
+    public static final String CVALUE_TYPE_FLOAT = "float";
+    public static final String CVALUE_TYPE_DOUBLE = "double";
+    public static final String CVALUE_TYPE_INTEGER = "integer";
+    public static final String CVALUE_TYPE_FILENAME_PATTERN = "filenamePattern";
+    public static final String CVALUE_TYPE_FILENAME = "filename";
 
     public static final String CVALUE_PREFIX_BASEPATH = "BASEPATH_";
     public static final String CVALUE_PREFIX_TOOL = "TOOL_";

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -44,18 +44,18 @@ class ConfigurationIssue {
     static enum ConfigurationIssueTemplate {
         detachedDollarCharacter(
                 ConfigurationIssueLevel.CVALUE_WARNING,
-                "Several variables contain plain dollar sign(s). Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file.",
+                "Variables contain plain dollar sign(s). Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file.",
                 "Variable '#REPLACE_0#' contains plain dollar sign(s) without braces. Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
         ),
         valueAndTypeMismatch(
                 ConfigurationIssueLevel.CVALUE_ERROR,
-                "Several variables in your configuration mismatch regarding their type and value. See the extended logs for more information.",
+                "Variables in your configuration mismatch regarding their type and value. See the extended logs for more information.",
                 "The value of variable named '#REPLACE_0#' is not of its declared type '#REPLACE_1#'."
         ),
         inproperVariableExpression(
                 ConfigurationIssueLevel.CVALUE_WARNING,
-                "Several variables in your configuration might use malformatted variable imports. Variable imports must look like \${variable identifier}, nesting is forbidden.",
-                "Variable '#REPLACE_0#' might use malformatted variable imports. Variable imports must look like \${variable identifier}, nesting is forbidden."
+                "Variables in your configuration appear to misuse variable imports. Import variables like \${variable identifier}, nesting like '\${\${innerVar }}' is forbidden and it must not be empty.",
+                "Variable '#REPLACE_0#' might use malformatted variable imports. Import variables like \${variable identifier}, nesting like '\${\${innerVar}}' is forbidden and it must not be empty."
         )
 
         final ConfigurationIssueLevel level

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -49,7 +49,7 @@ class ConfigurationIssue {
         ),
         inproperVariableExpression(
                 ConfigurationIssueLevel.CVALUE_WARNING,
-                "Several variables in your configuration might misuse the variable import wrong. A variable needs to be imported into another value with \${variable identifiert}.",
+                "Several variables in your configuration might misuse the variable import wrong. A variable needs to be imported into another value with \${variable identifier}.",
                 "The variable named '#REPLACE_0#' might misuse the variable import. Make sure, that all intended variable imports are non-escaped and formed like \${variable identifier}. Also, variable nesting is not allowed."
         )
 

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -44,7 +44,7 @@ class ConfigurationIssue {
     static enum ConfigurationIssueTemplate {
         detachedDollarCharacter(
                 ConfigurationIssueLevel.CVALUE_WARNING,
-                "Several variables in your configuration contain one or more dollar signs. As this might impose problems in your cluster jobs, check the entries in your job configuration files. See the extended logs for more information.",
+                "Several variables contain plain dollar sign(s). Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file.",
                 "Variable '#REPLACE_0#' contains plain dollar sign(s) without braces. Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
         ),
         valueAndTypeMismatch(
@@ -54,8 +54,8 @@ class ConfigurationIssue {
         ),
         inproperVariableExpression(
                 ConfigurationIssueLevel.CVALUE_WARNING,
-                "Several variables in your configuration might misuse the variable import wrong. A variable needs to be imported into another value with \${variable identifier}.",
-                "The variable named '#REPLACE_0#' might misuse the variable import. Make sure, that all intended variable imports are non-escaped and formed like \${variable identifier}. Also, variable nesting is not allowed."
+                "Several variables in your configuration might use malformatted variable imports. Variable imports must look like \${variable identifier}, nesting is forbidden.",
+                "Variable '#REPLACE_0#' might use malformatted variable imports. Variable imports must look like \${variable identifier}, nesting is forbidden."
         )
 
         final ConfigurationIssueLevel level

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -37,15 +37,20 @@ class ConfigurationIssue {
      * Various templates for configuration related issues.
      */
     static enum ConfigurationIssueTemplate {
-        unattachedDollarCharacter(
+        detachedDollarCharacter(
                 ConfigurationIssueLevel.CVALUE_WARNING,
                 "Several variables in your configuration contain one or more dollar signs. As this might impose problems in your cluster jobs, check the entries in your job configuration files. See the extended logs for more information.",
-                "The variable named '#REPLACE_0#' contains one or more dollar signs, which do not belong to a Roddy variable definition (\${variable identifier}). This might impose problems, so make sure, that your results job configuration is created in the way you want."
+                "Variable '#REPLACE_0#' contains plain dollar sign(s) without braces. Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
         ),
         valueAndTypeMismatch(
                 ConfigurationIssueLevel.CVALUE_ERROR,
                 "Several variables in your configuration mismatch regarding their type and value. See the extended logs for more information.",
-                "The value of variable named '#REPLACE_0#' does not match the variables type '#REPLACE_1#'."
+                "The value of variable named '#REPLACE_0#' is not of its declared type '#REPLACE_1#'."
+        ),
+        inproperVariableExpression(
+                ConfigurationIssueLevel.CVALUE_WARNING,
+                "Several variables in your configuration might misuse the variable import wrong. A variable needs to be imported into another value with \${variable identifiert}.",
+                "The variable named '#REPLACE_0#' might misuse the variable import. Make sure, that all intended variable imports are non-escaped and formed like \${variable identifier}. Also, variable nesting is not allowed."
         )
 
         final ConfigurationIssueLevel level

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
 import groovy.transform.CompileStatic

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
@@ -6,7 +6,6 @@
 
 package de.dkfz.roddy.config
 
-
 import de.dkfz.roddy.Roddy
 import de.dkfz.roddy.config.loader.ConfigurationLoadError
 import de.dkfz.roddy.config.validation.BashValidator
@@ -24,16 +23,7 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 import static de.dkfz.roddy.StringConstants.*
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BOOLEAN
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FILENAME
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FILENAME_PATTERN
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_PATH
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
+import static de.dkfz.roddy.config.ConfigurationConstants.*
 
 /**
  * A configuration value
@@ -80,9 +70,6 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
      * API Level 3.4+
      */
     final boolean valid
-
-    @Deprecated
-    final boolean invalid
 
     /**
      * API Level 3.4+
@@ -142,7 +129,6 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         if (tags != null)
             this.tags.addAll(tags)
         valid = validator.validate(this)
-        invalid = !valid
     }
 
     /**
@@ -160,7 +146,6 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         this.tags << "ELEVATED"
         this.validator = parent.validator // Do not revalidate, this is much too expensive for many values
         this.valid = parent.valid
-        this.invalid = parent.invalid
     }
 
 
@@ -287,10 +272,6 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
             if (value.startsWith("\${DIR_BUNDLED_FILES}") || value.startsWith("\${DIR_RODDY}"))
                 temp = Roddy.getApplicationDirectory().getAbsolutePath() + FileSystemAccessProvider.getInstance().getPathSeparator() + temp
 
-            if (temp.contains(ConfigurationConstants.CVALUE_PLACEHOLDER_EXECUTION_DIRECTORY)) {
-                String pd = context.getExecutionDirectory().getAbsolutePath()
-                temp = temp.replace(ConfigurationConstants.CVALUE_PLACEHOLDER_EXECUTION_DIRECTORY, pd)
-            }
             _toFileCache = new File(temp)
             return _toFileCache
         } catch (Exception ex) {
@@ -414,16 +395,13 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         }
     }
 
-    @Deprecated
+    boolean isValid() {
+        return valid
+    }
+
     boolean isInvalid() {
         return !valid
     }
-
-    @Deprecated
-    void setInvalid(boolean invalid) {
-        // Not used anymore, invalid is not overriden.
-    }
-
 
     private List<String> _bashArrayToStringList() {
         String vTemp = value.substring(1, value.length() - 2).trim() //Split away () and leading or trailing white characters.

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
@@ -15,6 +15,7 @@ import de.dkfz.roddy.config.validation.FileSystemValidator
 import de.dkfz.roddy.core.Analysis
 import de.dkfz.roddy.core.DataSet
 import de.dkfz.roddy.core.ExecutionContext
+import de.dkfz.roddy.execution.io.ExecutionService
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.tools.CollectionHelperMethods
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods
@@ -108,8 +109,8 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
     /**
      * API Level 3.4+
      */
-    ConfigurationValue(Configuration config = null, double value) {
-        this(config, value.toString(), "double")
+    ConfigurationValue(Configuration config = null, String id, double value) {
+        this(config, id, value.toString(), "double")
     }
 
     ConfigurationValue(Configuration config, String id, String value) {
@@ -126,7 +127,7 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
 
     ConfigurationValue(Configuration config, String id, String value, String type, String description, List<String> tags) {
         this.id = id
-        this.value = value
+        this.value = value != null ? replaceObsoleteVariableIdentifiers(value) : null
         this.configuration = config
         this.type = !RoddyConversionHelperMethods.isNullOrEmpty(type) ? type : determineTypeOfValue(value)
         this.description = description
@@ -136,6 +137,11 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         invalid = !valid
     }
 
+    /**
+     * Copy constructor for cvalue elevation
+     * @param config
+     * @param parent
+     */
     private ConfigurationValue(Configuration config, ConfigurationValue parent) {
         this.id = parent.id
         this.value = parent.value
@@ -144,7 +150,7 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         this.description = parent.description
         this.tags += parent.tags
         this.tags << "ELEVATED"
-        this.validator = parent.validator // Do not revalidate
+        this.validator = parent.validator // Do not revalidate, this is much too expensive for many values
         this.valid = parent.valid
         this.invalid = parent.invalid
     }
@@ -152,6 +158,19 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
 
     ConfigurationValue elevate(Configuration newParent) {
         return new ConfigurationValue(newParent, this)
+    }
+
+    @Deprecated
+    static String replaceObsoleteVariableIdentifiers(String cval) {
+        ([
+                '$USERNAME' : '${USERNAME}',
+                '$USERGROUP': '${USERGROUP}',
+                '$USERHOME' : '${USERHOME}',
+                '$PWD'      : "\${$ExecutionService.RODDY_CVALUE_DIRECTORY_EXECUTION}"
+        ] as Map<String, String>).each { String k, String v ->
+            cval = cval.replace(k, v)
+        }
+        return cval
     }
 
     @Override
@@ -213,14 +232,6 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         return "string"
     }
 
-    private String replaceString(String src, String pattern, String text) {
-        if (src.contains(pattern)) {
-            return src.replace(pattern, text)
-        }
-        return src
-    }
-
-
     private String checkAndCorrectPathThrow(String temp) throws ConfigurationError {
         String curUserPath = (new File("")).getAbsolutePath()
         String applicationDirectory = Roddy.getApplicationDirectory().getAbsolutePath()
@@ -257,41 +268,12 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
      * @param dataSet
      * @return
      */
-    File toFile(Analysis analysis, DataSet dataSet) throws ConfigurationError {
-        File f = toFile(analysis)
+    File toFile(Analysis analysis, DataSet dataSet = null) throws ConfigurationError {
+        String temp = new File(toEvaluatedValue([], id, value ?: "", configuration)).absolutePath
 
-        String temp = f.getAbsolutePath()
-        temp = temp.contains("\${" + Constants.PID + "}") ? replaceString(temp, "\${" + Constants.PID + "}", dataSet.getId()) : temp
-        temp = temp.contains("\${" + Constants.PID_CAP + "}") ? replaceString(temp, "\${" + Constants.PID_CAP + "}", dataSet.getId()) : temp
-        temp = temp.contains("\${" + Constants.DATASET + "}") ? replaceString(temp, "\${" + Constants.DATASET + "}", dataSet.getId()) : temp
-        temp = temp.contains("\${" + Constants.DATASET_CAP + "}") ? replaceString(temp, "\${" + Constants.DATASET_CAP + "}", dataSet.getId()) : temp
+        if (analysis) temp = toEvaluatedValue([], id, temp, analysis.configuration)
+        if (dataSet) temp = toEvaluatedValue([], id, temp, dataSet.configuration)
 
-        return new File(temp)
-    }
-
-    File toFile(Analysis analysis) {
-        if (analysis == null) return toFile()
-
-        String temp = toFile().getAbsolutePath()
-        temp = replaceConfigurationBasedValues(temp, analysis.getConfiguration())
-        temp = replaceString(temp, "\${" + Constants.PROJECT_NAME + "}", analysis.getProject().getName())
-        temp = checkAndCorrectPath(temp)
-
-        String userID = analysis.getUsername()
-        String groupID = analysis.getUsergroup()
-
-        if (userID != null) {
-            temp = replaceString(temp, "\$USERNAME", userID)
-            temp = replaceString(temp, "\${USERNAME}", userID)
-        }
-        if (groupID != null) {
-            temp = replaceString(temp, "\$USERGROUP", groupID)
-            temp = replaceString(temp, "\${USERGROUP}", groupID)
-        }
-
-        String ud = FileSystemAccessProvider.getInstance().getUserDirectory().getAbsolutePath()
-        temp = replaceString(temp, "\$USERHOME", ud)
-        temp = replaceString(temp, "\${USERHOME}", ud)
         temp = checkAndCorrectPath(temp)
 
         return new File(temp)
@@ -307,7 +289,7 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         }
 
         if (context == null) {
-            _toFileCache = toFile()
+            _toFileCache = new File(value)
             return _toFileCache
         }
         try {
@@ -325,37 +307,6 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         } catch (Exception ex) {
             return null
         }
-    }
-
-    static String replaceConfigurationBasedValues(String temp, Configuration configuration) {
-        String[] allValues = temp.split("/")//File.separator);
-        for (int i = 0; i < allValues.length; i++) {
-            if (!allValues[i].startsWith('$')) continue
-            String cValName = allValues[i].substring(2, allValues[i].length() - 1)
-            if (!configuration.getConfigurationValues().hasValue(cValName))
-                continue
-            ConfigurationValue cval = configuration.getConfigurationValues().get(cValName)
-            if (cValName.toLowerCase().contains("directory") || cval.type.equals("path")) {
-                temp = temp.replace(allValues[i], replaceConfigurationBasedValues(cval.value, configuration))
-            } else {
-                temp = temp.replace(allValues[i], cval.toString())
-            }
-        }
-        return temp
-    }
-
-    File toFile(Map<String, String> replacements) {
-        String temp = value
-
-        for (String key : replacements.keySet()) {
-            String val = replacements.get(key)
-            temp = temp.replace(key, val)
-        }
-        return new File(temp)
-    }
-
-    File toFile() {
-        return new File(value)
     }
 
     Boolean toBoolean() {
@@ -397,45 +348,42 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
         return Long.parseLong(value)
     }
 
-    Pattern variableDetection = Pattern.compile('[$][{][a-zA-Z0-9_]*[}]')
+    static final Pattern variableDetection = Pattern.compile('[$][{][a-zA-Z0-9_]*[}]')
 
     @Override
     String toString() {
-        return toString(new LinkedList<>())
+        return toEvaluatedValue([], id, value, configuration)
     }
 
-    @Deprecated
-    String toString(List<String> blackList) {
-        return toEvaluatedValue(blackList)
-    }
+    static String toEvaluatedValue(List<String> blackList, String valueID, String initialValue, Configuration configuration) {
 
-    String toEvaluatedValue(List<String> blackList) {
-        String temp = value
+        String temp = initialValue
         if (configuration != null) {
-            List<String> valueIDs = getIDsForParentValues()
-            if (CollectionHelperMethods.intersects(blackList, valueIDs)) {
-                ConfigurationError exc = new ConfigurationError("Cyclic dependency found for cvalue '" + this.id + "' in file " + (configuration.preloadedConfiguration != null ? configuration.preloadedConfiguration.file : configuration.getID()), configuration, "Cyclic dependency", null)
+            List<String> valueIDs = getIDsForParentValues(temp)
+            if (blackList.intersect(valueIDs as Iterable<String>)) {
+                def badFile = configuration.preloadedConfiguration != null ? configuration.preloadedConfiguration.file : configuration.getID()
+                ConfigurationError exc = new ConfigurationError("Cyclic dependency found for cvalue '${valueID}' in file '${badFile}'", configuration, "Cyclic dependency", null)
                 configuration.addLoadError(new ConfigurationLoadError(configuration, "cValues", exc.getMessage(), exc))
                 throw exc
             }
-
+            def configurationValues = configuration.getConfigurationValues()
             for (String vName : valueIDs) {
-                if (configuration.getConfigurationValues().hasValue(vName)) {
-                    List<String> subBlackList = new LinkedList<>(blackList)
-                    subBlackList.add(vName)
-                    temp = temp.replace("\${" + vName + '}', configuration.getConfigurationValues().get(vName).toString(subBlackList))
+                if (configurationValues.hasValue(vName)) {
+                    List<String> subBlackList = blackList + [vName]
+                    ConfigurationValue subValue = configurationValues[vName] as ConfigurationValue
+                    temp = temp.replace("\${$vName}", toEvaluatedValue(subBlackList, subValue.id, subValue.value, subValue.configuration))
                 }
             }
         }
         return temp
     }
 
-    List<String> getIDsForParentValues() {
+    static List<String> getIDsForParentValues(String value) {
         List<String> parentValues = new LinkedList<>()
 
         Matcher m = variableDetection.matcher(value)
         // Findall is not available in standard java, so I use groovy here.
-        for (String s : ConfigurationValueHelper.callFindAllForPatternMatcher(m)) {
+        for (String s : m.findAll()) {
             String vName = s.replaceAll("[\${}]", "")
             parentValues.add(vName)
         }

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueHelper.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ContainerParent.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ContainerParent.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/DerivedFromFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/DerivedFromFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/EmptyResourceSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/EmptyResourceSet.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
@@ -5,6 +5,7 @@
  */
 
 package de.dkfz.roddy.config
+
 /**
  * a custom enumeration class which allows the definition of enumerations in configuration files.
  */
@@ -17,32 +18,13 @@ class Enumeration implements RecursiveOverridableMapContainer.Identifiable {
 
     private final LinkedHashMap<String, EnumerationValue> values = new LinkedHashMap<String, EnumerationValue>()
 
-    /**
-     * API Level 3.4+
-     */
-    static Enumeration getDefaultCValueTypeEnumeration() {
-        Enumeration _def = new Enumeration("cvalueType", [
-                new EnumerationValue('filename', "de.dkfz.roddy.config.validation.FileSystemValidator"),
-                new EnumerationValue('filenamePattern', "de.dkfz.roddy.config.validation.FileSystemValidator"),
-                new EnumerationValue('path', "de.dkfz.roddy.config.validation.FileSystemValidator"),
-                new EnumerationValue('bashArray', "de.dkfz.roddy.config.validation.BashValidator"),
-                new EnumerationValue('boolean', "de.dkfz.roddy.config.validation.DefaultValidator"),
-                new EnumerationValue('integer', "de.dkfz.roddy.config.validation.DefaultValidator"),
-                new EnumerationValue('float', "de.dkfz.roddy.config.validation.DefaultValidator"),
-                new EnumerationValue('double', "de.dkfz.roddy.config.validation.DefaultValidator"),
-                new EnumerationValue('string', "de.dkfz.roddy.config.validation.DefaultValidator"),
-        ])
-        return _def
-    }
-
-    Enumeration(String name, List<EnumerationValue> values, String description = "", Enumeration enumeration = null) {
+    Enumeration(String name, List<EnumerationValue> values, String description = "") {
         if (!name)
             throw new RuntimeException("A enumeration must have a valid name.")
         this.name = name
         this.description = description
         if (!values)
             throw new RuntimeException("There must be some enumeration values. An enumeration cannot be empty.")
-//        this.values.putAll(enumeration.values);
         final Enumeration THIS = this
         values.each { EnumerationValue ev -> THIS.values[ev.id] = ev }
     }

--- a/RoddyCore/src/de/dkfz/roddy/config/EnumerationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/EnumerationValue.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/FileStageFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FileStageFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static de.dkfz.roddy.Constants.DEFAULT;
 import static de.dkfz.roddy.StringConstants.EMPTY;
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_PATH;
 
 /**
  * Filename patterns are stored in a configuration file. They are project specific and should be fully configurable.
@@ -171,7 +172,7 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
                     String cvalID = s.substring(2, s.length() - 1);
                     ConfigurationValue cval = cfg.getConfigurationValues().get(cvalID);
 
-                    String pathSup = cval.getType().equals("path") ? cval.toFile(context).getAbsolutePath() : cval.toString();
+                    String pathSup = cval.getType().equals(CVALUE_TYPE_PATH) ? cval.toFile(context).getAbsolutePath() : cval.toString();
                     pathSup = pathSup.replace(Roddy.getApplicationDirectory().getAbsolutePath() + "/", ""); //Remove Roddy application folder from path...
                     src = src.replace(s, pathSup);
                 }

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternDependency.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternDependency.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/OnMethodFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnMethodFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/OnScriptParameterFilenamePattern.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnScriptParameterFilenamePattern.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/OnToolFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnToolFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/PreloadedConfiguration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/PreloadedConfiguration.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ProjectConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ProjectConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING;
+
 /**
  * Helps configurations to store overridable versions of configuration values and other things
  */
@@ -109,7 +111,7 @@ public class RecursiveOverridableMapContainerForConfigurationValues
     }
 
     public void put(String id, String value) {
-        this.put(id, value, "string");
+        this.put(id, value, CVALUE_TYPE_STRING);
     }
 
 }

--- a/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
@@ -6,6 +6,8 @@ import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
 
 import java.io.File;
 
+import static de.dkfz.roddy.config.ConfigurationConstants.*;
+
 public class RoddyAppConfig extends AppConfig {
 
     public RoddyAppConfig() {
@@ -27,7 +29,7 @@ public class RoddyAppConfig extends AppConfig {
 
     public boolean getOrSetBooleanApplicationProperty(String pName, boolean defaultValue) throws ConfigurationError {
         try {
-            return Boolean.parseBoolean(getOrSetApplicationProperty(pName, String.valueOf(defaultValue), "boolean"));
+            return Boolean.parseBoolean(getOrSetApplicationProperty(pName, String.valueOf(defaultValue), CVALUE_TYPE_BOOLEAN));
         } catch (IllegalArgumentException e) {
             throw new ConfigurationError(e.getMessage(), pName, e);
         }
@@ -43,7 +45,7 @@ public class RoddyAppConfig extends AppConfig {
 
     public String getOrSetApplicationProperty(String pName, String defaultValue) {
         try {
-            return getOrSetApplicationProperty(pName, defaultValue, "string");
+            return getOrSetApplicationProperty(pName, defaultValue, CVALUE_TYPE_STRING);
         } catch (ConfigurationError e) {
             throw new RuntimeException("type = 'string' should never throw ConfigurationError", e);
         }
@@ -54,13 +56,13 @@ public class RoddyAppConfig extends AppConfig {
         assert(null != type);
         String value;
         switch (type) {
-            case "string":
+            case CVALUE_TYPE_STRING:
                 value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
                 break;
-            case "path":
+            case CVALUE_TYPE_PATH:
                 value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
                 break;
-            case "boolean":
+            case CVALUE_TYPE_BOOLEAN:
                 if (!RoddyConversionHelperMethods.isBoolean(defaultValue)) {
                     throw new RuntimeException("Trying to get boolean via getOrSetApplicationProperty with non-boolean defaultValue: " + defaultValue);
                 }

--- a/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config;
 
 import de.dkfz.roddy.RunMode;
@@ -57,6 +62,12 @@ public class RoddyAppConfig extends AppConfig {
         String value;
         switch (type) {
             case CVALUE_TYPE_STRING:
+                value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
+                break;
+            case CVALUE_TYPE_INTEGER:
+                if (!RoddyConversionHelperMethods.isInteger(defaultValue)) {
+                    throw new ConfigurationError(String.format("The value for '%s' is not of type '%s'", pName, type), pName);
+                }
                 value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
                 break;
             case CVALUE_TYPE_PATH:

--- a/RoddyCore/src/de/dkfz/roddy/config/TestAnalysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/TestAnalysis.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileGroupParameter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileGroupParameter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameterCheckCondition.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameterCheckCondition.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolStringParameter.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolStringParameter.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolTupleParameter.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolTupleParameter.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/UnknownConfigurationFileTypeException.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/UnknownConfigurationFileTypeException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -19,6 +19,11 @@ import groovy.transform.CompileStatic
 
 import java.util.logging.Level
 import static Constants.RODDY_CONFIGURATION_MAGICSTRING
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_PATH
 
 
 /**
@@ -310,13 +315,13 @@ class BashConverter extends ConfigurationConverter {
         } else {
             String tmp
 
-            if (cv.type && cv.type.toLowerCase() == "basharray") {
+            if (cv.type && cv.type.toLowerCase() == CVALUE_TYPE_BASH_ARRAY) {
                 return new StringBuilder("${declareVar} ${cv.id}=${addQuotesIfRequested(cv.toString(), autoQuoteArrays)}".toString())
-            } else if (cv.type && cv.type.toLowerCase() == "integer") {
+            } else if (cv.type && cv.type.toLowerCase() == CVALUE_TYPE_INTEGER) {
                 return new StringBuilder("${declareInt} ${cv.id}=${cv.toString()}".toString())
-            } else if (cv.type && ["double", "float"].contains(cv.type.toLowerCase())) {
+            } else if (cv.type && [CVALUE_TYPE_DOUBLE, CVALUE_TYPE_FLOAT].contains(cv.type.toLowerCase())) {
                 return new StringBuilder("${declareVar} ${cv.id}=${cv.toString()}".toString())
-            } else if (cv.type && cv.type.toLowerCase() == "path") {
+            } else if (cv.type && cv.type.toLowerCase() == CVALUE_TYPE_PATH) {
                 tmp = "${cv.toFile(context)}".toString()
             } else {
                 if (cv.value.startsWith("-") || cv.value.startsWith("*")) {

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -194,7 +194,7 @@ class BashConverter extends ConfigurationConverter {
 
             for (ConfigurationValue cv in listOfUnsortedValues.values().findAll { !isValidationRule(it) && !isComment(it) }) {
 
-                List<String> dependenciesToOtherValues = cv.getIDsForParentValues()
+                List<String> dependenciesToOtherValues = ConfigurationValue.getIDsForParentValues(cv.value)
 
                 // Check, how many dependencies to other values are set and find out for each dependency, if
                 // it was resolved in a former loop run or if it is a blacklisted value.

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/ConfigurationConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/ConfigurationConverter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters;

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/XMLConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/XMLConverter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/YAMLConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/YAMLConverter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
@@ -46,6 +46,9 @@ import java.text.ParseException
 import java.util.logging.Level
 
 import static de.dkfz.roddy.StringConstants.*
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_PATH
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_PATH
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 
 /**
  * Factory for loading, importing, exporting and writing configuration files.
@@ -863,7 +866,7 @@ class ConfigurationFactory {
     private ConfigurationValue readConfigurationValue(NodeChild cvalueNode, Configuration config) {
         String key = cvalueNode.@name.text()
         String value = cvalueNode.@value.text()
-        String type = extractAttributeText(cvalueNode, "type", "string")
+        String type = extractAttributeText(cvalueNode, "type", CVALUE_TYPE_STRING)
         List<String> tags = extractAttributeText(cvalueNode, "tags", null)?.split(StringConstants.COMMA)
 
         if (!cvalueNode.attributes().containsKey("name"))
@@ -875,7 +878,7 @@ class ConfigurationFactory {
         //any directory to "path". In case of the output directories, this was a bad thing! So we know about
         //this specific type of variable and just set it to path at any time.
         if (key.endsWith("OutputDirectory"))
-            type = "path"
+            type = CVALUE_TYPE_PATH
         String description = extractAttributeText(cvalueNode, "description")
         return new ConfigurationValue(config, key, value, type, description, tags)
     }

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoaderException.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
@@ -32,6 +32,8 @@ import groovy.transform.TypeCheckingMode
 import groovy.util.slurpersupport.NodeChild
 import groovy.util.slurpersupport.NodeChildren
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FILENAME
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 import static de.dkfz.roddy.config.loader.ConfigurationFactory.extractAttributeText
 
 /**
@@ -239,7 +241,7 @@ class ProcessingToolReader {
             return parseTuple(child, toolID)
         } else if (type == "filegroup") {
             return parseFileGroup(child, toolID)
-        } else if (type == "string") {
+        } else if (type == CVALUE_TYPE_STRING) {
             ToolStringParameter.ParameterSetbyOptions setby = Enum.valueOf(ToolStringParameter.ParameterSetbyOptions.class, extractAttributeText(child, "setby", ToolStringParameter.ParameterSetbyOptions.callingCode.name()))
 
             String pName = readAttribute(child, "scriptparameter")
@@ -262,7 +264,7 @@ class ProcessingToolReader {
         Class _cls = LibrariesFactory.getInstance().loadRealOrSyntheticClass(cls, BaseFile.class.name)
 
         String pName = readAttribute(child, "scriptparameter")
-        String fnPattern = readAttributeOrDefault(child, "filename")
+        String fnPattern = readAttributeOrDefault(child, CVALUE_TYPE_FILENAME)
         String fnpSelTag = extractAttributeText(child, "selectiontag", extractAttributeText(child, "fnpatternselectiontag", Constants.DEFAULT))
         String parentFileVariable = extractAttributeText(child, "variable", null) //This is only the case for child files.
         ToolFileParameterCheckCondition check = new ToolFileParameterCheckCondition(extractAttributeText(child, "check", "true"))

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/BashScriptChecker.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/BashScriptChecker.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/BashValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/BashValidator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidationError.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidationError.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueCombinationValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueCombinationValidator.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueValidator.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -12,11 +12,7 @@ import de.dkfz.roddy.config.ConfigurationValue
 import de.dkfz.roddy.config.EnumerationValue
 import groovy.transform.CompileStatic
 
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BOOLEAN
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
+import static de.dkfz.roddy.config.ConfigurationConstants.*
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.*
 
 /**
@@ -84,9 +80,10 @@ class DefaultValidator extends ConfigurationValueValidator {
 
     /** Match either a detached dollar (withouth esacpe and brace) somewhere in the text
      *   OR a non escaped detached dollar at line end.
-     *   OR a detached dollar string '$'
+     *   OR a detached dollar string '$'.
+     *   OR a detached dollar at the beginning of the line.
      */
-    static String matchDetachedDollars = /([^\\][$][^{])|([^\\][$]$)|(^[$]$)/
+    static String matchDetachedDollars = /([^\\][$][^{])|([^\\][$]$)|(^[$]$)|(^[$][^{])/
 
     boolean areDollarCharactersProperlyUsed(ConfigurationValue cv) {
         if (!cv.value.contains('$')) return true

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -40,7 +40,7 @@ class DefaultValidator extends ConfigurationValueValidator {
         if (configurationValue.value == null) return true
 
         boolean result = isConfigurationValueTypeCorrect(configurationValue, ev)
-        result &= areDollarCharactersProperlyUsed(configurationValue)
+        result &= areDollarCharactersAttached(configurationValue)
         result &= areVariablesProperlyDefined(configurationValue)
         this.result = result
         return result
@@ -78,14 +78,14 @@ class DefaultValidator extends ConfigurationValueValidator {
         temp
     }
 
-    /** Match either a detached dollar (withouth esacpe and brace) somewhere in the text
+    /** Match either a detached dollar (without escape and brace) somewhere in the text
      *   OR a non escaped detached dollar at line end.
      *   OR a detached dollar string '$'.
      *   OR a detached dollar at the beginning of the line.
      */
     static String matchDetachedDollars = /([^\\][$][^{])|([^\\][$]$)|(^[$]$)|(^[$][^{])/
 
-    boolean areDollarCharactersProperlyUsed(ConfigurationValue cv) {
+    boolean areDollarCharactersAttached(ConfigurationValue cv) {
         if (!cv.value.contains('$')) return true
 
         String temp = removeEscapedEscapeCharacters(cv.value)

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -12,6 +12,11 @@ import de.dkfz.roddy.config.ConfigurationValue
 import de.dkfz.roddy.config.EnumerationValue
 import groovy.transform.CompileStatic
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BOOLEAN
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.*
 
 /**
@@ -36,6 +41,8 @@ class DefaultValidator extends ConfigurationValueValidator {
         super.warnings.clear()
         EnumerationValue ev = configurationValue.getEnumerationValueType()
 
+        if (configurationValue.value == null) return true
+
         boolean result = isConfigurationValueTypeCorrect(configurationValue, ev)
         result &= areDollarCharactersProperlyUsed(configurationValue)
         result &= areVariablesProperlyDefined(configurationValue)
@@ -44,17 +51,17 @@ class DefaultValidator extends ConfigurationValueValidator {
     }
 
     private boolean isConfigurationValueTypeCorrect(ConfigurationValue configurationValue, EnumerationValue ev) {
-        String evID = ev != null ? ev.getId() : "string"
+        String evID = ev != null ? ev.getId() : CVALUE_TYPE_STRING
         try {
-            if (evID == "integer") {
+            if (evID == CVALUE_TYPE_INTEGER) {
                 configurationValue.toInt()
-            } else if (evID == "boolean") {
+            } else if (evID == CVALUE_TYPE_BOOLEAN) {
                 configurationValue.toBoolean()
-            } else if (evID == "float") {
+            } else if (evID == CVALUE_TYPE_FLOAT) {
                 configurationValue.toFloat()
-            } else if (evID == "double") {
+            } else if (evID == CVALUE_TYPE_DOUBLE) {
                 configurationValue.toDouble()
-            } else if (evID == "string") {
+            } else if (evID == CVALUE_TYPE_STRING) {
             }
         } catch (Exception e) {
             super.errors << new ConfigurationIssue(valueAndTypeMismatch, configurationValue.id, evID)

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -46,15 +46,15 @@ class DefaultValidator extends ConfigurationValueValidator {
     private boolean isConfigurationValueTypeCorrect(ConfigurationValue configurationValue, EnumerationValue ev) {
         String evID = ev != null ? ev.getId() : "string"
         try {
-            if (evID.equals("integer")) {
+            if (evID == "integer") {
                 configurationValue.toInt()
-            } else if (evID.equals("boolean")) {
+            } else if (evID == "boolean") {
                 configurationValue.toBoolean()
-            } else if (evID.equals("float")) {
+            } else if (evID == "float") {
                 configurationValue.toFloat()
-            } else if (evID.equals("double")) {
+            } else if (evID == "double") {
                 configurationValue.toDouble()
-            } else if (evID.equals("string")) {
+            } else if (evID == "string") {
             }
         } catch (Exception e) {
             super.errors << new ConfigurationIssue(valueAndTypeMismatch, configurationValue.id, evID)

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/FileSystemValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/FileSystemValidator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/Invalidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/Invalidator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptChecker.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptChecker.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptValidator.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/WholeConfigurationValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/WholeConfigurationValidator.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/XSDValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/XSDValidator.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
@@ -78,27 +78,19 @@ class Analysis {
     }
 
     String getUsername() {
-        try {
-            return FileSystemAccessProvider.getInstance().callWhoAmI()
-        } catch (Exception e) {
-            return "UNKNOWN"
-        }
+        return FileSystemAccessProvider.getInstance().callWhoAmI()
     }
 
     String getUsergroup() {
-        try {
-            //Get the default value.
-            String groupID = FileSystemAccessProvider.getInstance().getMyGroup()
+        //Get the default value.
+        String groupID = FileSystemAccessProvider.getInstance().getMyGroup()
 
-            //If it is configured, get the group id from the config.
-            boolean processSetUserGroup = getConfiguration().getConfigurationValues().getBoolean(ConfigurationConstants.CVALUE_PROCESS_OPTIONS_SETUSERGROUP, true)
-            if (processSetUserGroup) {
-                groupID = getConfiguration().getConfigurationValues().getString(ConfigurationConstants.CFG_OUTPUT_FILE_GROUP, groupID)
-            }
-            return groupID
-        } catch (Exception e) {
-            return "UNKNOWN"
+        //If it is configured, get the group id from the config.
+        boolean processSetUserGroup = getConfiguration().getConfigurationValues().getBoolean(ConfigurationConstants.CVALUE_PROCESS_OPTIONS_SETUSERGROUP, true)
+        if (processSetUserGroup) {
+            groupID = getConfiguration().getConfigurationValues().getString(ConfigurationConstants.CFG_OUTPUT_FILE_GROUP, groupID)
         }
+        return groupID
     }
 
     private ContextConfiguration _analysisConfiguration = null
@@ -120,10 +112,10 @@ class Analysis {
         if (_analysisConfiguration == null) {
             _analysisConfiguration = new ContextConfiguration((AnalysisConfiguration) this.configuration, (ProjectConfiguration) this.project.getConfiguration())
             [
-                    'USERNAME' : getUsername(),
-                    'USERGROUP' : getUsergroup(),
-                    'USERHOME' : FileSystemAccessProvider.getInstance().getUserDirectory().getAbsolutePath(),
-                    (Constants.PROJECT_NAME) : project.name,
+                    (Constants.USERNAME)    : getUsername(),
+                    (Constants.USERGROUP)   : getUsergroup(),
+                    (Constants.USERHOME)    : FileSystemAccessProvider.getInstance().getUserDirectory().getAbsolutePath(),
+                    (Constants.PROJECT_NAME): project.name,
             ].each { String k, String v ->
                 _analysisConfiguration.configurationValues << new ConfigurationValue(_analysisConfiguration, k, v)
             }
@@ -202,7 +194,7 @@ class Analysis {
 
         for (DataSet ds : selectedDatasets) {
             if (level.allowedToSubmitJobs && !canStartJobs(ds)) {
-                logger.postAlwaysInfo("The " + Constants.PID + " " + ds.getId() + " is still running and will be skipped for the process.")
+                logger.postAlwaysInfo("The ${Constants.DATASET_HR} ${ds.id} is still running and will be skipped for the process.")
                 continue
             }
 
@@ -243,7 +235,7 @@ class Analysis {
             }
 
             if (!test && !canStartJobs(ds)) {
-                logger.postAlwaysInfo("The " + Constants.PID + " " + ds.getId() + " is still running and will be skipped for the process.")
+                logger.postAlwaysInfo("The ${Constants.DATASET_HR} ${ds.id} is still running and will be skipped for the process.")
                 continue
             }
 
@@ -343,7 +335,7 @@ class Analysis {
      */
     void runDeferredContext(final ExecutionContext ec) {
 //        ThreadGroup
-        Thread t = Thread.start(String.format("Deferred execution context execution for " + Constants.PID + " %s", ec.getDataSet().getId()), {
+        Thread t = Thread.start(String.format("Deferred execution context execution for " + Constants.DATASET_HR + " %s", ec.getDataSet().getId()), {
             executeRun(ec)
         })
     }
@@ -546,7 +538,7 @@ class Analysis {
         for (Object entry : entries) {
             messages.append("\n\t* ").append(entry.toString())
         }
-        if(logAlways)
+        if (logAlways)
             logger.postAlwaysInfo(messages.toString())
         else
             logger.sometimes(messages.toString())

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core
@@ -103,6 +103,19 @@ class Analysis {
 
     private ContextConfiguration _analysisConfiguration = null
 
+    /**
+     * Tests using analysis objects will need to implement the following:
+     *
+     * static {
+     *   ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+     *   FileSystemAccessProvider.initializeProvider(true)
+     * }
+     *
+     * If they don't, tests will fail with a NullPointerException!
+     *
+     * Alternatively, you could use the RoddyTestSpec class as a base for Spock tests.
+     * @return
+     */
     AnalysisConfiguration getConfiguration() {
         if (_analysisConfiguration == null) {
             _analysisConfiguration = new ContextConfiguration((AnalysisConfiguration) this.configuration, (ProjectConfiguration) this.project.getConfiguration())
@@ -247,10 +260,7 @@ class Analysis {
     }
 
     private boolean canStartJobs(DataSet ds) {
-        if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning)) {
-            throw new RuntimeException("Feature toggle forbidSubmissionOnRunning is currently unsupported due to lack of use by users. If you need it contact the developers.")
-        }
-        return !Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning) || !hasKnownRunningJobs(ds)
+        return !Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning) || !hasKnownRunningJobs(ds);
     }
 
     boolean hasKnownRunningJobs(DataSet ds) {

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
@@ -394,14 +394,12 @@ public class Analysis {
                         failedJobs += "\n\t" + job.getJobID() + ",\t" + job.getJobName();
                 }
                 if (failedJobs.length() > 0)
-                    context.addError(ExecutionContextError.EXECUTION_JOBFAILED.expand("One or more jobs failed to execute:" + failedJobs));
+                    context.addError(ExecutionContextError.EXECUTION_JOBFAILED.expand("Job(s) failed to execute:" + failedJobs));
             }
 
             // Print out informational messages like infos, warnings, errors
             // Only print them out if !QUERY_STATUS and the runmode is testrun or testrerun.
             if ((!preventLoggingOnQueryStatus || (context.getExecutionContextLevel() != ExecutionContextLevel.QUERY_STATUS))) {
-                // Print out configuration errors (for context configuration! Not only for analysis)
-                // Don't know, if this is the right place.
                 printErrorsAndWarnings(context)
             }
         }

--- a/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformation.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformation.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformationListener.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformationListener.java
@@ -1,7 +1,7 @@
 ///*
-// * Copyright (c) 2016 eilslabs.
+// * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
 // *
-// * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+// * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
 // */
 //
 //package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
@@ -256,12 +256,12 @@ class CohortDataRuntimeServiceExtension {
         for (filter in pidFilters) {
             boolean faulty = !validateCohortDataSetLoadingString(filter)
             if (faulty) {
-                logger.severe("The ${Constants.PID} string ${filter} is malformed.")
+                logger.severe("The ${Constants.DATASET_HR} string ${filter} is malformed.")
                 foundFaulty = true
             }
         }
         if (foundFaulty) {
-            logger.severe("The dataset list you provided contains errors, Roddy will not start jobs.")
+            logger.severe("The ${Constants.DATASET_HR} list you provided contains errors, Roddy will not start jobs.")
             return false
         }
         return true

--- a/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/CohortDataSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/CohortDataSet.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
@@ -6,6 +6,10 @@
 
 package de.dkfz.roddy.core;
 
+import de.dkfz.roddy.Constants;
+import de.dkfz.roddy.config.Configuration;
+import de.dkfz.roddy.config.ConfigurationValue;
+import de.dkfz.roddy.config.RecursiveOverridableMapContainerForConfigurationValues;
 import de.dkfz.roddy.execution.io.BaseMetadataTable;
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider;
 
@@ -82,6 +86,22 @@ public class DataSet extends InfoObject implements Serializable {
 
     public Project getProject() {
         return project;
+    }
+
+    /**
+     * This table contains some minimal information about the dataset and is meant
+     * for INTERNAL USE ONLY!
+     * @return
+     */
+    public Configuration getConfiguration() {
+        Configuration c = new Configuration(null);
+
+        RecursiveOverridableMapContainerForConfigurationValues configurationValues = c.getConfigurationValues();
+        configurationValues.put(Constants.PID, id);
+        configurationValues.put(Constants.PID_CAP, id);
+        configurationValues.put(Constants.DATASET, id);
+        configurationValues.put(Constants.DATASET_CAP, id);
+        return c;
     }
 
     public BaseMetadataTable getMetadataTable() {

--- a/RoddyCore/src/de/dkfz/roddy/core/DataSetListener.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/DataSetListener.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextError.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextError.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextLevel.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextLevel.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextSubLevel.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextSubLevel.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/Initializable.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Initializable.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/LibraryEntry.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/LibraryEntry.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ProcessingFlag.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProcessingFlag.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/Project.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Project.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core
@@ -16,6 +16,8 @@ import de.dkfz.roddy.config.loader.ConfigurationFactory
 import de.dkfz.roddy.config.loader.ConfigurationLoaderException
 import de.dkfz.roddy.config.validation.XSDValidator
 import de.dkfz.roddy.execution.io.MetadataTableFactory
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import de.dkfz.roddy.plugins.ClassLoaderHelper
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.plugins.PluginInfo
 import de.dkfz.roddy.plugins.PluginInfoMap
@@ -386,6 +388,13 @@ class ProjectLoader {
 
         if (analysis == null)
             throw new ProjectLoaderException("Could not load analysis ${analysisID}")
+
+        try {
+            def _cls = new ClassLoaderHelper().searchForClass(analysis.configuration.workflowClass)
+            if (!_cls) throw new ClassNotFoundException("Class not found ${analysis.configuration.workflowClass}.")
+        } catch (ClassNotFoundException ex) {
+            throw new ProjectLoaderException("The configured workflow class ${analysis.configuration.workflowClass} for analysis ${analysisID} does not exist or could not be loaded.\n\t- Is the plugin properly compiled?\n\t- Is the workflow class spelled correctly?")
+        }
     }
 
     AnalysisConfiguration loadAnalysisConfigurationFromProjectConfigurationOrFail(ProjectConfiguration projectConfiguration, String analysisID) {

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -16,12 +16,7 @@ import de.dkfz.roddy.config.loader.ConfigurationFactory
 import de.dkfz.roddy.config.loader.ConfigurationLoaderException
 import de.dkfz.roddy.config.validation.XSDValidator
 import de.dkfz.roddy.execution.io.MetadataTableFactory
-import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
-import de.dkfz.roddy.plugins.ClassLoaderHelper
-import de.dkfz.roddy.plugins.LibrariesFactory
-import de.dkfz.roddy.plugins.PluginInfo
-import de.dkfz.roddy.plugins.PluginInfoMap
-import de.dkfz.roddy.plugins.PluginLoaderException
+import de.dkfz.roddy.plugins.*
 import de.dkfz.roddy.tools.RoddyIOHelperMethods
 
 import java.lang.reflect.InvocationTargetException
@@ -243,7 +238,7 @@ class ProjectLoader {
 
         lines << "inputBaseDirectory=" + Roddy.customBaseInputDirectory
         lines << "outputBaseDirectory=" + Roddy.customBaseOutputDirectory
-        lines << "outputAnalysisBaseDirectory=\${outputBaseDirectory}/\${${Constants.PID}}".toString()
+        lines << "outputAnalysisBaseDirectory=\${outputBaseDirectory}/\${${Constants.DATASET}}".toString()
 
         projectID = "CFreeMode_" + Integer.toHexString(configurationFileName.hashCode())
 

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoaderException.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
@@ -6,18 +6,14 @@
 
 package de.dkfz.roddy.core
 
-import de.dkfz.roddy.config.Configuration
-import de.dkfz.roddy.config.ConfigurationError
-import de.dkfz.roddy.config.ConfigurationValue
-import de.dkfz.roddy.execution.jobs.Job
 import de.dkfz.roddy.Constants
 import de.dkfz.roddy.Roddy
 import de.dkfz.roddy.StringConstants
-import de.dkfz.roddy.config.ConfigurationConstants
-import de.dkfz.roddy.config.ToolEntry
+import de.dkfz.roddy.config.*
 import de.dkfz.roddy.execution.io.BaseMetadataTable
 import de.dkfz.roddy.execution.io.MetadataTableFactory
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import de.dkfz.roddy.execution.jobs.Job
 import de.dkfz.roddy.knowledge.files.BaseFile
 import de.dkfz.roddy.tools.LoggerWrapper
 import de.dkfz.roddy.tools.RoddyIOHelperMethods
@@ -327,9 +323,9 @@ class RuntimeService {
      * @return
      */
     String extractDataSetIDFromPath(File path, Analysis analysis) {
-        String pattern = getOutputAnalysisBaseCV(analysis).toFile(analysis).getAbsolutePath()
+        String pattern = getOutputAnalysisBaseDirectoryCV(analysis).toFile(analysis).getAbsolutePath()
         RoddyIOHelperMethods.getPatternVariableFromPath(pattern, Constants.DATASET, path.getAbsolutePath()).
-                orElse(RoddyIOHelperMethods.getPatternVariableFromPath(pattern, Constants.PID, path.getAbsolutePath()).
+                orElse(RoddyIOHelperMethods.getPatternVariableFromPath(pattern, Constants.DATASET, path.getAbsolutePath()).
                         orElse(Constants.UNKNOWN))
     }
 
@@ -461,18 +457,18 @@ class RuntimeService {
      * @param context
      * @return
      */
-    private ConfigurationValue getOutputAnalysisBaseCV(Analysis analysis) {
+    private ConfigurationValue getOutputAnalysisBaseDirectoryCV(Analysis analysis) {
         return analysis.getConfiguration().getConfigurationValues().
                 get(ConfigurationConstants.CFG_OUTPUT_ANALYSIS_BASE_DIRECTORY,
                         getOutputBaseDirectory(analysis).toString())
     }
 
     File getOutputAnalysisBaseDirectory(DataSet dataSet, Analysis analysis) {
-        return getOutputAnalysisBaseCV(analysis).toFile(analysis, dataSet)
+        return getOutputAnalysisBaseDirectoryCV(analysis).toFile(analysis, dataSet)
     }
 
     File getOutputAnalysisBaseDirectory(ExecutionContext context) {
-        return getOutputAnalysisBaseCV(context.analysis).toFile(context)
+        return getOutputAnalysisBaseDirectoryCV(context.analysis).toFile(context)
     }
 
 

--- a/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
@@ -450,6 +450,7 @@ class RuntimeService {
         return getOutputBaseDirectoryCV(analysis.configuration).toFile(analysis)
     }
 
+    @Deprecated
     File getOutputBaseDirectory(DataSet dataSet, Analysis analysis) {
         return getOutputBaseDirectoryCV(analysis.configuration).toFile(analysis, dataSet)
     }
@@ -471,7 +472,7 @@ class RuntimeService {
     }
 
     File getOutputAnalysisBaseDirectory(ExecutionContext context) {
-        return getOutputAnalysisBaseDirectory(context.dataSet, context.analysis)
+        return getOutputAnalysisBaseCV(context.analysis).toFile(context)
     }
 
 

--- a/RoddyCore/src/de/dkfz/roddy/core/SuperCohortDataSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/SuperCohortDataSet.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
@@ -22,6 +22,12 @@ import groovy.transform.CompileStatic
 import java.lang.reflect.Method
 import java.util.concurrent.ExecutionException
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BOOLEAN
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+
 /**
  * A worklow can be created and executed to process a set of data.
  *
@@ -125,19 +131,19 @@ abstract class Workflow {
 
     final void setEnvBoolean(String id, boolean value) { cvalue(id, value) }
 
-    final void setEnvBashArray(String id, String value) { cvalue(id, value, "bashArray") }
+    final void setEnvBashArray(String id, String value) { cvalue(id, value, CVALUE_TYPE_BASH_ARRAY) }
 
     def getEnv(String id) {
         ConfigurationValue value = context.configuration.configurationValues[id]
-        if (value.type == "integer") {
+        if (value.type == CVALUE_TYPE_INTEGER) {
             return value.toInt()
-        } else if (value.type == "float") {
+        } else if (value.type == CVALUE_TYPE_FLOAT) {
             return value.toFloat()
-        } else if (value.type == "double") {
+        } else if (value.type == CVALUE_TYPE_DOUBLE) {
             return value.toDouble()
-        } else if (value.type == "boolean") {
+        } else if (value.type == CVALUE_TYPE_BOOLEAN) {
             return value.toBoolean()
-        } else if (value.type == "bashArray") {
+        } else if (value.type == CVALUE_TYPE_BASH_ARRAY) {
             return value.toStringList()
         } else {
             return value.toString()
@@ -170,7 +176,7 @@ abstract class Workflow {
      * @param value
      */
     final void cvalue(String id, int value) {
-        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), "integer")
+        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), CVALUE_TYPE_INTEGER)
     }
 
     /**
@@ -179,7 +185,7 @@ abstract class Workflow {
      * @param value
      */
     final void cvalue(String id, float value) {
-        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), "float")
+        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), CVALUE_TYPE_FLOAT)
     }
 
     /**
@@ -188,7 +194,7 @@ abstract class Workflow {
      * @param value
      */
     final void cvalue(String id, double value) {
-        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), "double")
+        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), CVALUE_TYPE_DOUBLE)
     }
 
     /**
@@ -197,7 +203,7 @@ abstract class Workflow {
      * @param value
      */
     final void cvalue(String id, boolean value) {
-        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), "boolean")
+        context.configurationValues << new ConfigurationValue(context.configuration, id, value.toString(), CVALUE_TYPE_BOOLEAN)
     }
 
     /**

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/BaseMetadataTable.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/BaseMetadataTable.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
@@ -609,7 +609,7 @@ abstract class ExecutionService implements BEExecutionService {
             File folder, PluginInfo pInfo ->
                 def bPathID = folder.getName()
                 String basepathConfigurationID = ConfigurationConverter.createVariableName(ConfigurationConstants.CVALUE_PREFIX_BASEPATH, bPathID)
-                cfg.getConfigurationValues().add(new ConfigurationValue(basepathConfigurationID, RoddyIOHelperMethods.assembleLocalPath(dstExecutionDirectory, RuntimeService.DIRNAME_ANALYSIS_TOOLS, bPathID).getAbsolutePath(), "string"))
+                cfg.getConfigurationValues().add(new ConfigurationValue(basepathConfigurationID, RoddyIOHelperMethods.assembleLocalPath(dstExecutionDirectory, RuntimeService.DIRNAME_ANALYSIS_TOOLS, bPathID).getAbsolutePath(),  ConfigurationConstants.CVALUE_TYPE_STRING))
         }
 
         Map<String, List<Map<String, String>>> mapOfInlineScripts = [:]

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
@@ -1,34 +1,25 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io
 
-import de.dkfz.roddy.config.loader.ConfigurationLoaderException
-import de.dkfz.roddy.execution.BEExecutionService
-import de.dkfz.roddy.execution.jobs.BEJobResult
-import de.dkfz.roddy.execution.jobs.Command
-import de.dkfz.roddy.execution.jobs.Job
-import de.dkfz.roddy.execution.jobs.JobManagerOptions
-import de.dkfz.roddy.execution.jobs.JobState
-import de.dkfz.roddy.AvailableFeatureToggles
-import de.dkfz.roddy.Constants
-import de.dkfz.roddy.Roddy
-import de.dkfz.roddy.RunMode
-import de.dkfz.roddy.StringConstants
+import de.dkfz.roddy.*
 import de.dkfz.roddy.client.cliclient.RoddyCLIClient
 import de.dkfz.roddy.config.Configuration
 import de.dkfz.roddy.config.ConfigurationConstants
-import de.dkfz.roddy.config.loader.ConfigurationFactory
 import de.dkfz.roddy.config.ConfigurationValue
 import de.dkfz.roddy.config.ToolEntry
 import de.dkfz.roddy.config.converters.ConfigurationConverter
 import de.dkfz.roddy.config.converters.XMLConverter
+import de.dkfz.roddy.config.loader.ConfigurationFactory
+import de.dkfz.roddy.config.loader.ConfigurationLoaderException
 import de.dkfz.roddy.core.*
+import de.dkfz.roddy.execution.BEExecutionService
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
-import de.dkfz.roddy.execution.jobs.BEJobID
+import de.dkfz.roddy.execution.jobs.*
 import de.dkfz.roddy.execution.jobs.cluster.lsf.LSFCommand
 import de.dkfz.roddy.execution.jobs.cluster.pbs.PBSCommand
 import de.dkfz.roddy.execution.jobs.cluster.sge.SGECommand
@@ -69,20 +60,20 @@ abstract class ExecutionService implements BEExecutionService {
     static void initializeService(Class executionServiceClass, RunMode runMode) {
         executionService = (ExecutionService) executionServiceClass.getConstructors()[0].newInstance()
         if (runMode == RunMode.CLI) {
-            boolean isConnected = executionService.tryInitialize(true)
+            boolean isConnected = executionService.tryInitialize()
             if (!isConnected) {
                 int queryCount = 0
                 //If password is not stored, ask once for the password only, increase queryCount.
                 if (!Boolean.parseBoolean(Roddy.applicationConfiguration.getOrSetApplicationProperty(runMode, Constants.APP_PROPERTY_EXECUTION_SERVICE_STORE_PWD, Boolean.FALSE.toString()))) {
                     Roddy.applicationConfiguration.setApplicationProperty(runMode, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_PWD)
                     RoddyCLIClient.askForPassword()
-                    isConnected = executionService.tryInitialize(true)
+                    isConnected = executionService.tryInitialize()
                     queryCount++
                 }
                 for (; queryCount < 3 && !isConnected; queryCount++) {
                     //Wait for correct password, count to three?
                     RoddyCLIClient.performCommandLineSetup()
-                    isConnected = executionService.tryInitialize(true)
+                    isConnected = executionService.tryInitialize()
                 }
             }
         } else {
@@ -128,9 +119,10 @@ abstract class ExecutionService implements BEExecutionService {
     boolean initialize() {
     }
 
-    boolean tryInitialize(boolean waitFor) {
+    boolean tryInitialize() {
         try {
             long t1 = System.nanoTime()
+            initialize()
             logger.postSometimesInfo(RoddyIOHelperMethods.printTimingInfo("initialize exec service", t1, System.nanoTime()))
             return true
         } catch (Exception ex) {
@@ -138,17 +130,7 @@ abstract class ExecutionService implements BEExecutionService {
         }
     }
 
-    boolean tryInitialize() {
-        try {
-            return initialize()
-        } catch (Exception ex) {
-            return false
-        }
-    }
-
-    void destroy() {
-//        this.listOfListeners.clear();
-    }
+    void destroy() {}
 
     protected abstract ExecutionResult _execute(String string, boolean waitFor, boolean ignoreErrors, OutputStream outputStream)
 
@@ -195,7 +177,7 @@ abstract class ExecutionService implements BEExecutionService {
             throw new IOException("Job log file ${jobLog} does not exist")
 
         Long jobLogSize = FileSystemAccessProvider.instance.fileSize(jobLog)
-        Long maximumJobLogSize = context.configurationValues.get("maximumJobLogSize", (1024*1024*10).toString()).toLong()
+        Long maximumJobLogSize = context.configurationValues.get("maximumJobLogSize", (1024 * 1024 * 10).toString()).toLong()
         if (jobLogSize > maximumJobLogSize)
             throw new IOException("Job log file of ${jobLogSize} byte is larger than permitted size ${maximumJobLogSize}")
 
@@ -456,7 +438,7 @@ abstract class ExecutionService implements BEExecutionService {
         File roddyBundledFilesDirectory = Roddy.getBundledFilesDirectory()
 
         provider.checkDirectories([executionBaseDirectory, executionDirectory, temporaryDirectory, lockFilesDirectory], context, true)
-        if(context.executionContextLevel.allowedToSubmitJobs){
+        if (context.executionContextLevel.allowedToSubmitJobs) {
             logger.always("Creating the following execution directory to store information about this process:")
             logger.always("\t${executionDirectory.getAbsolutePath()}")
         }

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/FileAttributes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/FileAttributes.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
@@ -6,15 +6,11 @@
 
 package de.dkfz.roddy.execution.io
 
+import de.dkfz.roddy.SystemProperties
 import de.dkfz.roddy.config.Configuration
 import de.dkfz.roddy.config.ConfigurationConstants
 import de.dkfz.roddy.config.ConfigurationValue
-import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
-import de.dkfz.roddy.execution.jobs.Command
-import de.dkfz.roddy.execution.jobs.Job
 import de.dkfz.roddy.tools.LoggerWrapper
-
-import java.lang.reflect.Field
 
 /**
  * The local execution service executes commands on the local machine. For this groovy's execute() method is used.
@@ -26,7 +22,7 @@ class LocalExecutionService extends ExecutionService {
 
     @Override
     String getUsername() {
-        return System.getProperty("user.name")
+        return SystemProperties.getUserName()
     }
 
     @Override

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/MetadataTableFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/MetadataTableFactory.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/RemoteExecutionService.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/RemoteExecutionService.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -161,7 +161,7 @@ class SSHExecutionService extends RemoteExecutionService {
                 t2 = System.nanoTime()
                 logger.sometimes(RoddyIOHelperMethods.printTimingInfo("start ssh client session", t1, t2))
             } catch (UnknownHostException ex) {
-                Roddy.exit(ExitReasons.unknownSSHHost)
+                Roddy.exitWithMessage(ExitReasons.unknownSSHHost)
             } catch (UserAuthException ex) {
                 logger.severe(
                         [

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -18,6 +18,7 @@ import com.jcraft.jsch.agentproxy.sshj.AuthAgent
 import de.dkfz.roddy.Constants
 import de.dkfz.roddy.ExitReasons
 import de.dkfz.roddy.Roddy
+import de.dkfz.roddy.SystemProperties
 import de.dkfz.roddy.config.RoddyAppConfig
 import de.dkfz.roddy.execution.io.FileAttributes
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
@@ -216,8 +217,8 @@ class SSHExecutionService extends RemoteExecutionService {
 
         private void _initialize() {
             RoddyAppConfig appConf = Roddy.applicationConfiguration
-            String sshUser = appConf.getOrSetApplicationProperty(Roddy.getRunMode(), Constants.APP_PROPERTY_EXECUTION_SERVICE_USER, System.getProperty("user.name"))
-            if (sshUser == "USERNAME") sshUser = System.getProperty("user.name") //Get the local name if USERNAME is set
+            String sshUser = appConf.getOrSetApplicationProperty(Roddy.getRunMode(), Constants.APP_PROPERTY_EXECUTION_SERVICE_USER, SystemProperties.getUserName())
+            if (sshUser == Constants.USERNAME) sshUser = SystemProperties.getUserName() //Get the local name if USERNAME is set
             String sshMethod = appConf.getOrSetApplicationProperty(Roddy.getRunMode(), Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_PWD)
 
             if (![Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_PWD, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_KEYFILE, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_SSHAGENT].contains(sshMethod))
@@ -312,8 +313,8 @@ class SSHExecutionService extends RemoteExecutionService {
     @Override
     String getUsername() {
         String userName = Roddy.applicationConfiguration.getOrSetApplicationProperty(Roddy.getRunMode(), Constants.APP_PROPERTY_EXECUTION_SERVICE_USER)
-        if (userName == "USERNAME") //Get the local username.
-            userName = System.getProperty("user.name")
+        if (userName == Constants.USERNAME) //Get the local username.
+            userName = SystemProperties.getUserName()
         return userName
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs
@@ -186,7 +186,7 @@ class BashCommandSet extends ShellCommandSet {
 
     @Override
     String getListFilesInDirectoryCommand(File path) {
-        return "find ${path.absolutePath} -type f -maxdepth 1"
+        return "find -L ${path.absolutePath} -type f -maxdepth 1"
     }
 
     @Override
@@ -197,7 +197,7 @@ class BashCommandSet extends ShellCommandSet {
 
     @Override
     String getListFullDirectoryContentRecursivelyCommand(File f, int depth, FileType selectedType, boolean detailed) {
-        StringBuilder sb = new StringBuilder("find ")
+        StringBuilder sb = new StringBuilder("find -L ")
         sb << "\"" << f.absolutePath << "\""
 
         if (depth > 0) sb << " -maxdepth ${depth}"

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
@@ -8,16 +8,17 @@ package de.dkfz.roddy.execution.io.fs
 
 import de.dkfz.roddy.Constants
 import de.dkfz.roddy.Roddy
+import de.dkfz.roddy.SystemProperties
 import de.dkfz.roddy.config.converters.ConfigurationConverter
-import de.dkfz.roddy.plugins.LibrariesFactory
-import de.dkfz.roddy.tools.ComplexLine
-import de.dkfz.roddy.tools.LoggerWrapper
-import de.dkfz.roddy.tools.RoddyIOHelperMethods
 import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.execution.io.ExecutionResult
 import de.dkfz.roddy.execution.io.ExecutionService
 import de.dkfz.roddy.execution.io.FileAttributes
 import de.dkfz.roddy.knowledge.files.BaseFile
+import de.dkfz.roddy.plugins.LibrariesFactory
+import de.dkfz.roddy.tools.ComplexLine
+import de.dkfz.roddy.tools.LoggerWrapper
+import de.dkfz.roddy.tools.RoddyIOHelperMethods
 import groovy.io.FileType
 import org.apache.commons.io.filefilter.WildcardFileFilter
 
@@ -419,7 +420,7 @@ public class FileSystemAccessProvider {
     public File getUserDirectory() {
         if (_userHome == null) {
             if (ExecutionService.getInstance().isLocalService()) {
-                String jHomeVar = System.getProperty("user.home");
+                String jHomeVar = SystemProperties.getUserHome();
                 _userHome = new File(jHomeVar)
             } else {
                 String cmd = commandSet.getUserDirectoryCommand();

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemInfoObject.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemInfoObject.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/NoNoFileSystemAccessProvider.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/NoNoFileSystemAccessProvider.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/ShellCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/ShellCommandSet.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/CopyFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/CopyFileCommand.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/IOCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/IOCommand.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/ReadFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/ReadFileCommand.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/StoreFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/StoreFileCommand.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobConstants.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobManager.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobManager.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedFile.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedJob.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedJob.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/ReadOutJob.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/ReadOutJob.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/ScriptCallingMethod.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/ScriptCallingMethod.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/StaticScriptProviderClass.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/StaticScriptProviderClass.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflow.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows
 
 import de.dkfz.roddy.Roddy

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflow.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows;
 
 import de.dkfz.roddy.config.ConfigurationError

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflowToolCall.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflowToolCall.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows
 
 import de.dkfz.roddy.config.ConfigurationError

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.brawlworkflows

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/AbstractFileObjectTuple.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/AbstractFileObjectTuple.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObject.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObject.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObjectTupleFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObjectTupleFactory.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStageSettings.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStageSettings.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFile.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFileGroup.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/ITestdataSource.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/ITestdataSource.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/IndexedFileObjects.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/IndexedFileObjects.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/LoadedFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/LoadedFile.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple10.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple10.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple11.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple11.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple12.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple12.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple13.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple13.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple14.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple14.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple15.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple15.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple2.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple2.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple3.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple3.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple4.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple4.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple5.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple5.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple6.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple6.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple7.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple7.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple8.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple8.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple9.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple9.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.methods

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/GenericJobInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/GenericJobInfo.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.nativeworkflows

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.nativeworkflows

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.java
@@ -1,7 +1,7 @@
 ///*
-// * Copyright (c) 2016 eilslabs.
+// * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
 // *
-// * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+// * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
 // */
 //
 //package de.dkfz.roddy.knowledge.nativeworkflows;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflowConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflowConverter.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.nativeworkflows

--- a/RoddyCore/src/de/dkfz/roddy/plugins/BuildInfoFileHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/BuildInfoFileHelper.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/ClassLoaderHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/ClassLoaderHelper.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/JarFulPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/JarFulPluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/JarLessPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/JarLessPluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/NativePluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/NativePluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginDirectoryInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginDirectoryInfo.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfo.java
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfo.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins;

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginType.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginType.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/SyntheticPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/SyntheticPluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/tools/CollectionHelperMethods.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/CollectionHelperMethods.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
@@ -8,6 +8,7 @@ package de.dkfz.roddy.tools
 
 import de.dkfz.roddy.Constants
 import de.dkfz.roddy.StringConstants
+import de.dkfz.roddy.SystemProperties
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.tools.versions.Version
 import de.dkfz.roddy.tools.versions.VersionLevel
@@ -27,7 +28,7 @@ final class RuntimeTools {
     }
 
     static String getJavaRuntimeVersion() {
-        String javaRuntimeVersion = System.getProperty("java.version").split("[.]")[0..1].join(".")
+        String javaRuntimeVersion = SystemProperties.getJavaVersion().split("[.]")[0..1].join(".")
         javaRuntimeVersion
     }
 
@@ -46,7 +47,7 @@ final class RuntimeTools {
     }
 
     static File getDevelopmentDistFolder() {
-        return new File(System.getProperty("user.dir"), "dist/bin/develop")
+        return new File(SystemProperties.getUserDir(), "dist/bin/develop")
     }
 
     static File getGroovyLibrary() {
@@ -58,9 +59,9 @@ final class RuntimeTools {
             logger.info("Loading groovy library from GroovyServ environment " + file)
             return file
         } else {
-            def file = new File(System.getProperty("java.class.path").split("[:]").find { new File(it).name.startsWith("groovy") })
+            def file = new File(SystemProperties.getJavaClasspath().split("[:]").find { new File(it).name.startsWith("groovy") })
             if (file == null)
-                throw new RuntimeException("Could not find groovy library in class path: " + System.getProperty("java.class.path"))
+                throw new RuntimeException("Could not find groovy library in class path: " + SystemProperties.getJavaClasspath())
             logger.info("Loading groovy library from local environment " + file)
             return file
         }

--- a/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/RoddyCore/src/de/dkfz/roddy/tools/ScannerWrapper.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/ScannerWrapper.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple2.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple2.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple3.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple3.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple5.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple5.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/imgs/icons_projectlist.svg
+++ b/RoddyCore/src/imgs/icons_projectlist.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  ~ Copyright (c) 2016 eilslabs.
+  ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <!-- Created with Inkscape (http://www.inkscape.org/) -->

--- a/RoddyCore/src/imgs/roddy.svg
+++ b/RoddyCore/src/imgs/roddy.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  ~ Copyright (c) 2016 eilslabs.
+  ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <!-- Created with Inkscape (http://www.inkscape.org/) -->

--- a/RoddyCore/src/java/io/RoddyFile.java
+++ b/RoddyCore/src/java/io/RoddyFile.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package java.io;

--- a/RoddyCore/src/logback.xml
+++ b/RoddyCore/src/logback.xml
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2017 eilslabs.
+  ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration>

--- a/RoddyCore/test/resources/exampleProject/config/projectsExampleMinimal.xml
+++ b/RoddyCore/test/resources/exampleProject/config/projectsExampleMinimal.xml
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2016 eilslabs.
+  ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='example' description='' imports="" usedresourcessize="s">

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2017 eilslabs.
+  ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysis' description='A test analysis for local and remote roddy workflow tests.' workflowClass='de.dkfz.roddy.core.Analysis'>

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (c) 2017 eilslabs.
+  ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysis' description='A test analysis for local and remote roddy workflow tests.' workflowClass='de.dkfz.roddy.core.Analysis'>

--- a/RoddyCore/test/src/de/dkfz/roddy/HELPERSCRIPTS/ConfigurationPreparatorTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/HELPERSCRIPTS/ConfigurationPreparatorTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.HELPERSCRIPTS

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyStartupModesIntegrativeUnitTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyStartupModesIntegrativeUnitTests.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
@@ -6,8 +6,8 @@
 
 package de.dkfz.roddy
 
-import de.dkfz.roddy.client.cliclient.CommandLineCall
 import de.dkfz.roddy.client.RoddyStartupModes
+import de.dkfz.roddy.client.cliclient.CommandLineCall
 import de.dkfz.roddy.config.ResourceSetSize
 import de.dkfz.roddy.execution.jobs.cluster.pbs.PBSJobManager
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods
@@ -31,7 +31,7 @@ class RoddyTest {
         return RoddyConversionHelperMethods.toBoolean(System.getenv(RUN_INTEGRATIONTESTS), false)
     }
 
-    private static File temporarySettingsDirectory = new File(System.getProperty("user.home"), ".RODDY_TEST_SETTINGS_DIRECTORY")
+    private static File temporarySettingsDirectory = new File(SystemProperties.getUserHome(), ".RODDY_TEST_SETTINGS_DIRECTORY")
 
     // Helper method to set a final static field accessible and writable!
     // Taken from: http://stackoverflow.com/questions/2474017/using-reflection-to-change-static-final-file-separatorchar-for-unit-testing/2474242#2474242

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy
+
+import de.dkfz.roddy.core.ContextResource
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import groovy.transform.CompileStatic
+import org.junit.ClassRule
+import org.junit.Rule
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Base class for Spock tests which does some basic initialization stuff.
+ */
+@CompileStatic
+class RoddyTestSpec extends Specification {
+
+    @Rule
+    final ContextResource contextResource = new ContextResource()
+
+    static {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
+    }
+}

--- a/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
@@ -9,6 +9,12 @@ package de.dkfz.roddy.client.cliclient
 import de.dkfz.roddy.config.ConfigurationValue
 import groovy.transform.CompileStatic
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
+
 /**
  * Created by heinold on 17.07.16.
  */
@@ -17,33 +23,33 @@ class CommandLineCallTest extends GroovyTestCase {
     void testGetSetConfigurationValues() {
         CommandLineCall clc = new CommandLineCall(["run", "prj@ana", "--cvalues=a:( a bash array ),b:1.0,c:2:double,d:'quoted string',e:1.0f,f:1"])
         ConfigurationValue cvalue = clc.getSetConfigurationValues()[0]
-        assert cvalue.type == "bashArray"
-        assert cvalue.id == "a";
-        assert cvalue.value == "( a bash array )";
+        assert cvalue.type == CVALUE_TYPE_BASH_ARRAY
+        assert cvalue.id == "a"
+        assert cvalue.value == "( a bash array )"
 
-        cvalue = clc.getSetConfigurationValues()[1];
-        assert cvalue.type == "double"
-        assert cvalue.id == "b";
-        assert cvalue.value == "1.0";
+        cvalue = clc.getSetConfigurationValues()[1]
+        assert cvalue.type == CVALUE_TYPE_DOUBLE
+        assert cvalue.id == "b"
+        assert cvalue.value == "1.0"
 
-        cvalue = clc.getSetConfigurationValues()[2];
-        assert cvalue.type == "double"
-        assert cvalue.id == "c";
-        assert cvalue.value == "2";
+        cvalue = clc.getSetConfigurationValues()[2]
+        assert cvalue.type == CVALUE_TYPE_DOUBLE
+        assert cvalue.id == "c"
+        assert cvalue.value == "2"
 
-        cvalue = clc.getSetConfigurationValues()[3];
-        assert cvalue.type == "string"
-        assert cvalue.id == "d";
-        assert cvalue.value == "'quoted string'";
+        cvalue = clc.getSetConfigurationValues()[3]
+        assert cvalue.type == CVALUE_TYPE_STRING
+        assert cvalue.id == "d"
+        assert cvalue.value == "'quoted string'"
 
-        cvalue = clc.getSetConfigurationValues()[4];
-        assert cvalue.type == "float"
-        assert cvalue.id == "e";
-        assert cvalue.value == "1.0f";
+        cvalue = clc.getSetConfigurationValues()[4]
+        assert cvalue.type == CVALUE_TYPE_FLOAT
+        assert cvalue.id == "e"
+        assert cvalue.value == "1.0f"
 
-        cvalue = clc.getSetConfigurationValues()[5];
-        assert cvalue.type == "integer"
-        assert cvalue.id == "f";
-        assert cvalue.value == "1";
+        cvalue = clc.getSetConfigurationValues()[5]
+        assert cvalue.type == CVALUE_TYPE_INTEGER
+        assert cvalue.id == "f"
+        assert cvalue.value == "1"
     }
 }

--- a/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient

--- a/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/RoddyCLIClientTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/RoddyCLIClientTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 //package de.dkfz.roddy.client.cliclient

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnectionTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnectionTests.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientServerTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientServerTests.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
@@ -29,7 +29,7 @@ import org.junit.rules.ExpectedException
 import java.lang.reflect.Method
 
 import static de.dkfz.roddy.Constants.DEFAULT
-import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.unattachedDollarCharacter
+import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.detachedDollarCharacter
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.valueAndTypeMismatch
 import static de.dkfz.roddy.config.ResourceSetSize.*
 
@@ -138,14 +138,14 @@ class ConfigurationFactoryTest {
         Configuration cfg = ConfigurationFactory.instance.loadConfiguration(pc)
         assert cfg.hasWarnings()
         assert cfg.warnings.size() == 2
-        assert cfg.warnings[0].id == unattachedDollarCharacter
-        assert cfg.warnings[0].message == "The variable named 'valWithDollars1' contains one or more dollar signs, which do not belong to a Roddy variable definition (\${variable identifier}). This might impose problems, so make sure, that your results job configuration is created in the way you want."
-        assert cfg.warnings[1].id == unattachedDollarCharacter
-        assert cfg.warnings[1].message == "The variable named 'valWithDollars2' contains one or more dollar signs, which do not belong to a Roddy variable definition (\${variable identifier}). This might impose problems, so make sure, that your results job configuration is created in the way you want."
+        assert cfg.warnings[0].id == detachedDollarCharacter
+        assert cfg.warnings[0].message == "Variable 'valWithDollars1' contains plain dollar sign(s) without braces. Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
+        assert cfg.warnings[1].id == detachedDollarCharacter
+        assert cfg.warnings[1].message == "Variable 'valWithDollars2' contains plain dollar sign(s) without braces. Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
         assert cfg.hasErrors()
         assert cfg.errors.size() == 1
         assert cfg.errors[0].id == valueAndTypeMismatch
-        assert cfg.errors[0].message == "The value of variable named 'valWithMismatch' does not match the variables type 'integer'."
+        assert cfg.errors[0].message == "The value of variable named 'valWithMismatch' is not of its declared type 'integer'."
     }
 
 
@@ -215,7 +215,7 @@ class ConfigurationFactoryTest {
         assert toolEntry.getInlineScriptName().equals("testscript.sh")
     }
     @Test
-    @Ignore("The factory does not have that methode anymore. ProcessingToolReader has one, but it returns a NullPointerException in this test.")
+    @Ignore("The factory does not have that method anymore. ProcessingToolReader has one, but it returns a NullPointerException in this test.")
     void testParseToolResourceSet() {
         Method parseToolResourceSet = ConfigurationFactory.getDeclaredMethod("parseToolResourceSet", NodeChild, Configuration)
         parseToolResourceSet.setAccessible(true)

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
@@ -41,8 +41,8 @@ class ConfigurationIssueSpec extends Specification {
 
         where:
         template                | messageContent | expectedLevel  | expectedCollectiveMessage
-        detachedDollarCharacter | smallArray     | CVALUE_WARNING | "Several variables contain plain dollar sign(s). Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
-        valueAndTypeMismatch    | largeArray     | CVALUE_ERROR   | "Several variables in your configuration mismatch regarding their type and value. See the extended logs for more information."
+        detachedDollarCharacter | smallArray     | CVALUE_WARNING | "Variables contain plain dollar sign(s). Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
+        valueAndTypeMismatch    | largeArray     | CVALUE_ERROR   | "Variables in your configuration mismatch regarding their type and value. See the extended logs for more information."
     }
 
 

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
@@ -41,7 +41,7 @@ class ConfigurationIssueSpec extends Specification {
 
         where:
         template                | messageContent | expectedLevel  | expectedCollectiveMessage
-        detachedDollarCharacter | smallArray     | CVALUE_WARNING | "Several variables in your configuration contain one or more dollar signs. As this might impose problems in your cluster jobs, check the entries in your job configuration files. See the extended logs for more information."
+        detachedDollarCharacter | smallArray     | CVALUE_WARNING | "Several variables contain plain dollar sign(s). Roddy does not interpret them as variables and cannot guarantee correct ordering of assignments for such variables in the job parameter file."
         valueAndTypeMismatch    | largeArray     | CVALUE_ERROR   | "Several variables in your configuration mismatch regarding their type and value. See the extended logs for more information."
     }
 

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
 import spock.lang.Shared

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
@@ -9,6 +9,8 @@ package de.dkfz.roddy.config
 
 import spock.lang.Specification
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+
 /**
  * Created by heinold on 22.07.16.
  */
@@ -44,7 +46,7 @@ class ConfigurationSpec extends Specification {
 
         // Shall be elevated but their warnings and errors shall only exist once!
         cfgA.configurationValues << new ConfigurationValue("vala", 'detached $ sign ')
-        cfgA.configurationValues << new ConfigurationValue("valb", 'type mismatch', "integer")
+        cfgA.configurationValues << new ConfigurationValue("valb", 'type mismatch', CVALUE_TYPE_INTEGER)
 
         then:
         cfgC.warnings.size() == 1

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
@@ -6,7 +6,7 @@
 
 package de.dkfz.roddy.config
 
-import groovy.transform.CompileStatic
+
 import spock.lang.Specification
 
 /**
@@ -43,12 +43,12 @@ class ConfigurationSpec extends Specification {
         cfgC.addParent(cfgB)
 
         // Shall be elevated but their warnings and errors shall only exist once!
-        cfgA.configurationValues << new ConfigurationValue("vala", 'unattached $ sign ')
+        cfgA.configurationValues << new ConfigurationValue("vala", 'detached $ sign ')
         cfgA.configurationValues << new ConfigurationValue("valb", 'type mismatch', "integer")
 
         then:
         cfgC.warnings.size() == 1
-        cfgC.warnings[0].id == ConfigurationIssue.ConfigurationIssueTemplate.unattachedDollarCharacter
+        cfgC.warnings[0].id == ConfigurationIssue.ConfigurationIssueTemplate.detachedDollarCharacter
 
         cfgC.errors.size() == 1
         cfgC.errors[0].id == ConfigurationIssue.ConfigurationIssueTemplate.valueAndTypeMismatch

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
@@ -8,10 +8,10 @@ class ConfigurationValueSpec extends Specification {
 //    }
 //
     @Shared
-    static final EnumerationValue evString = Enumeration.defaultCValueTypeEnumeration.getValue("string")
+    static final EnumerationValue evString = ConfigurationValue.defaultCValueTypeEnumeration.getValue("string")
 
     @Shared
-    static final EnumerationValue evInt = Enumeration.defaultCValueTypeEnumeration.getValue("integer")
+    static final EnumerationValue evInt = ConfigurationValue.defaultCValueTypeEnumeration.getValue("integer")
 
     def "get enumeration value type (cvalue type)"(cvalue, defaultType, expectedValue) {
         expect:

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
@@ -10,6 +10,9 @@ import org.junit.ClassRule
 import spock.lang.Shared
 import spock.lang.Specification
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
+
 class ConfigurationValueSpec extends Specification {
 //    def "GetEnumerationValueType"() {
 //    }
@@ -28,21 +31,21 @@ class ConfigurationValueSpec extends Specification {
     }
 
     @Shared
-    static final EnumerationValue evString = ConfigurationValue.defaultCValueTypeEnumeration.getValue("string")
+    static final EnumerationValue evString = ConfigurationValue.defaultCValueTypeEnumeration.getValue(CVALUE_TYPE_STRING)
 
     @Shared
-    static final EnumerationValue evInt = ConfigurationValue.defaultCValueTypeEnumeration.getValue("integer")
+    static final EnumerationValue evInt = ConfigurationValue.defaultCValueTypeEnumeration.getValue(CVALUE_TYPE_INTEGER)
 
     def "get enumeration value type (cvalue type)"(cvalue, defaultType, expectedValue) {
         expect:
         cvalue.getEnumerationValueType(defaultType) == expectedValue
 
         where:
-        cvalue                                       | defaultType | expectedValue
-        new ConfigurationValue("a", "b")             | null        | evString
-        new ConfigurationValue("a", "b")             | evString    | evString
-        new ConfigurationValue("b", "abc", "string") | null        | evString
-        new ConfigurationValue("c", 1)               | null        | evInt
+        cvalue                                                 | defaultType | expectedValue
+        new ConfigurationValue("a", "b")                       | null        | evString
+        new ConfigurationValue("a", "b")                       | evString    | evString
+        new ConfigurationValue("b", "abc", CVALUE_TYPE_STRING) | null        | evString
+        new ConfigurationValue("c", 1)                         | null        | evInt
     }
 
     def "test variable replacement for toFile()"() {

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
+import de.dkfz.roddy.RoddyTestSpec
 import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.core.ContextResource
 import de.dkfz.roddy.core.ExecutionContext
@@ -13,22 +19,7 @@ import spock.lang.Specification
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 
-class ConfigurationValueSpec extends Specification {
-//    def "GetEnumerationValueType"() {
-//    }
-//
-
-    @ClassRule
-    static ContextResource contextResource = new ContextResource() {
-        {
-            before()
-        }
-    }
-
-    def setupSpec() {
-        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
-        FileSystemAccessProvider.initializeProvider(true)
-    }
+class ConfigurationValueSpec extends RoddyTestSpec {
 
     @Shared
     static final EnumerationValue evString = ConfigurationValue.defaultCValueTypeEnumeration.getValue(CVALUE_TYPE_STRING)

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
@@ -1,5 +1,12 @@
 package de.dkfz.roddy.config
 
+import de.dkfz.roddy.RunMode
+import de.dkfz.roddy.core.ContextResource
+import de.dkfz.roddy.core.ExecutionContext
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import org.junit.ClassRule
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -7,6 +14,19 @@ class ConfigurationValueSpec extends Specification {
 //    def "GetEnumerationValueType"() {
 //    }
 //
+
+    @ClassRule
+    static ContextResource contextResource = new ContextResource() {
+        {
+            before()
+        }
+    }
+
+    def setupSpec() {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
+    }
+
     @Shared
     static final EnumerationValue evString = ConfigurationValue.defaultCValueTypeEnumeration.getValue("string")
 
@@ -23,5 +43,33 @@ class ConfigurationValueSpec extends Specification {
         new ConfigurationValue("a", "b")             | evString    | evString
         new ConfigurationValue("b", "abc", "string") | null        | evString
         new ConfigurationValue("c", 1)               | null        | evInt
+    }
+
+    def "test variable replacement for toFile()"() {
+        when:
+        ExecutionContext context = contextResource.createSimpleContext(ConfigurationValueSpec.class)
+        def values = context.configurationValues
+        values << new ConfigurationValue(context.configuration, "b", 'abc')
+        values << new ConfigurationValue(context.configuration, "c", 'def')
+        values << new ConfigurationValue(context.configuration, "a", '/tmp/${projectName}/${b}/something${c}fjfj/${dataSet}')
+        values << new ConfigurationValue(context.configuration, "complex", '/$USERHOME/$USERNAME/$USERGROUP')
+
+        then:
+        values["complex"].toFile(context.analysis, context.dataSet).absolutePath.count("\$") == 0
+        values["a"].toFile(context.analysis).absolutePath == "/tmp/TestProject/abc/somethingdeffjfj/\${dataSet}"
+        values["a"].toFile(context.analysis, context.dataSet).absolutePath == "/tmp/TestProject/abc/somethingdeffjfj/TEST_PID"
+    }
+
+    @Deprecated
+    def "test obsolete variable replacement upon cvalue creation"(value, expectedValue) {
+        expect:
+        new ConfigurationValue("bla", value).value == expectedValue
+
+        where:
+        value                | expectedValue
+        'a $USERNAME value'  | 'a ${USERNAME} value'
+        'a $USERGROUP value' | 'a ${USERGROUP} value'
+        'a $USERHOME value'  | 'a ${USERHOME} value'
+        'a $PWD value'       | "a \${$ExecutionService.RODDY_CVALUE_DIRECTORY_EXECUTION} value"
     }
 }

--- a/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
 import spock.lang.Specification

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolEntryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolEntryTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileGroupParameterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileGroupParameterTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileParameterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileParameterTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
@@ -23,6 +23,15 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BOOLEAN
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_PATH
+import static de.dkfz.roddy.config.ConfigurationConstants.DEBUG_OPTIONS_USE_EXECUTE_OUTPUT
+import static de.dkfz.roddy.config.ConfigurationConstants.DEBUG_OPTIONS_USE_EXTENDED_EXECUTE_OUTPUT
+
 /**
  * Created by heinold on 30.06.16.
  */
@@ -89,13 +98,13 @@ class BashConverterTest {
     private Configuration createTestConfiguration() {
         Configuration configuration = new Configuration(null);
         configuration.getConfigurationValues().addAll([
-                new ConfigurationValue(configuration, CVAL_OUTPUT_ANALYSIS_BASE_DIRECTORY, '${outputBaseDirectory}/Dideldum', "path"),
-                new ConfigurationValue(configuration, CVAL_TEST_OUTPUT_DIRECTORY, "testvalue", "path"),
-                new ConfigurationValue(configuration, CVAL_TEST_BASHARRAY, "( a b c d )", "bashArray"),
-                new ConfigurationValue(configuration, CVAL_TEST_BASHARRAY_QUOTES, "'( a b c d )'", "bashArray"),
-                new ConfigurationValue(configuration, CVAL_TEST_INTEGER, "100", "integer"),
-                new ConfigurationValue(configuration, CVAL_TEST_FLOAT, "1.0", "float"),
-                new ConfigurationValue(configuration, CVAL_TEST_DOUBLE, "1.0", "double"),
+                new ConfigurationValue(configuration, CVAL_OUTPUT_ANALYSIS_BASE_DIRECTORY, '${outputBaseDirectory}/Dideldum', CVALUE_TYPE_PATH),
+                new ConfigurationValue(configuration, CVAL_TEST_OUTPUT_DIRECTORY, "testvalue", CVALUE_TYPE_PATH),
+                new ConfigurationValue(configuration, CVAL_TEST_BASHARRAY, "( a b c d )", CVALUE_TYPE_BASH_ARRAY),
+                new ConfigurationValue(configuration, CVAL_TEST_BASHARRAY_QUOTES, "'( a b c d )'", CVALUE_TYPE_BASH_ARRAY),
+                new ConfigurationValue(configuration, CVAL_TEST_INTEGER, "100", CVALUE_TYPE_INTEGER),
+                new ConfigurationValue(configuration, CVAL_TEST_FLOAT, "1.0", CVALUE_TYPE_FLOAT),
+                new ConfigurationValue(configuration, CVAL_TEST_DOUBLE, "1.0", CVALUE_TYPE_DOUBLE),
                 new ConfigurationValue(configuration, CVAL_TEST_SPACE_QUOTES, "text with spaces"),
                 new ConfigurationValue(configuration, CVAL_TEST_TAB_QUOTES, "text\twith\ttabs"),
                 new ConfigurationValue(configuration, CVAL_TEST_NEWLINE_QUOTES, "text\nwith\nnewlines"),
@@ -140,7 +149,7 @@ class BashConverterTest {
                toString().
                trim() ==  "declare -x WRAPPED_SCRIPT_DEBUG_OPTIONS=\"-v -x -o pipefail \""
 
-        configuration.configurationValues.put(ConfigurationConstants.DEBUG_OPTIONS_USE_EXTENDED_EXECUTE_OUTPUT, "true", "boolean")
+        configuration.configurationValues.put(DEBUG_OPTIONS_USE_EXTENDED_EXECUTE_OUTPUT, "true", CVALUE_TYPE_BOOLEAN)
         assert new BashConverter().
                appendDebugVariables(configuration).
                toString().
@@ -148,8 +157,8 @@ class BashConverterTest {
                           "",
                           "export PS4='+(\${BASH_SOURCE}:\${LINENO}): \${FUNCNAME[0]: +\$ { FUNCNAME[0] }():}'"].join("\n")
 
-        configuration.configurationValues.put(ConfigurationConstants.DEBUG_OPTIONS_USE_EXECUTE_OUTPUT, "false", "boolean")
-        configuration.configurationValues.put(ConfigurationConstants.DEBUG_OPTIONS_USE_EXTENDED_EXECUTE_OUTPUT, "false", "boolean")
+        configuration.configurationValues.put(DEBUG_OPTIONS_USE_EXECUTE_OUTPUT, "false", CVALUE_TYPE_BOOLEAN)
+        configuration.configurationValues.put(DEBUG_OPTIONS_USE_EXTENDED_EXECUTE_OUTPUT, "false", CVALUE_TYPE_BOOLEAN)
         assert new BashConverter().
                        appendDebugVariables(configuration).
                        toString().
@@ -171,11 +180,10 @@ class BashConverterTest {
         def configuration = createTestConfiguration()
 
         File tmpDir = contextResource.tempFolder.newFile()
-        configuration.configurationValues.put(CVAL_OUTPUT_BASE_DIRECTORY, tmpDir.absolutePath, "path")
+        configuration.configurationValues.put(CVAL_OUTPUT_BASE_DIRECTORY, tmpDir.absolutePath, CVALUE_TYPE_PATH)
         Roddy.applicationConfiguration.getOrSetApplicationProperty(Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY, tmpDir.absolutePath)
 
         Map<String, String> listWiAutoQuoting = [
-                (CVAL_TEST_OUTPUT_DIRECTORY)           : "declare -x    testOutputDirectory=testvalue",
                 (CVAL_TEST_BASHARRAY)                  : "declare -x    testBashArray=\"( a b c d )\"",
                 (CVAL_TEST_BASHARRAY_QUOTES)           : "declare -x    testBashArrayQuotes='( a b c d )'",
                 (CVAL_TEST_INTEGER)                    : "declare -x -i testInteger=100",

--- a/RoddyCore/test/src/de/dkfz/roddy/config/converters/YAMLConverterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/converters/YAMLConverterTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -100,5 +100,6 @@ class DefaultValidatorSpec extends RoddyTestSpec {
         'abc${${var}}'     | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla')] | []
         'abc${'            | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla')] | []
         'ab${c'            | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla')] | []
+        '${}'              | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla')] | []
     }
 }

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -6,17 +6,10 @@
 package de.dkfz.roddy.config.validation
 
 import de.dkfz.roddy.RoddyTestSpec
-import de.dkfz.roddy.config.ConfigurationConstants
 import de.dkfz.roddy.config.ConfigurationIssue
 import de.dkfz.roddy.config.ConfigurationValue
-import spock.lang.Specification
 
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BOOLEAN
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
-import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
+import static de.dkfz.roddy.config.ConfigurationConstants.*
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.*
 
 class DefaultValidatorSpec extends RoddyTestSpec {
@@ -60,7 +53,7 @@ class DefaultValidatorSpec extends RoddyTestSpec {
         'bla bla'  | CVALUE_TYPE_BASH_ARRAY | true     | [] // Bash arrays need to be checked in a totally different way.
     }
 
-    def 'test check proper dollar sign usage in variables'(value, type, expected, expectedWarnings, expectedErrors) {
+    def 'test check proper dollar sign usage in variables'(String value, String type, Boolean expected, List<ConfigurationIssue> expectedWarnings, List<ConfigurationIssue> expectedErrors) {
         when:
         ConfigurationValue cval = new ConfigurationValue('bla', value, type)
 
@@ -82,6 +75,7 @@ class DefaultValidatorSpec extends RoddyTestSpec {
 
         // Not ok
         'abc$'                  | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
+        '$abc'                  | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
         'tr$ue'                 | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
         '$'                     | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
         'abc$\\{'               | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config.validation
 
+import de.dkfz.roddy.RoddyTestSpec
 import de.dkfz.roddy.config.ConfigurationConstants
 import de.dkfz.roddy.config.ConfigurationIssue
 import de.dkfz.roddy.config.ConfigurationValue
@@ -13,7 +19,7 @@ import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.*
 
-class DefaultValidatorSpec extends Specification {
+class DefaultValidatorSpec extends RoddyTestSpec {
 
     def 'test removeEscapedEscapeCharacters'(value, expected) {
         expect:

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -8,14 +8,28 @@ import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate
 
 class DefaultValidatorSpec extends Specification {
 
+    def 'test removeEscapedEscapeCharacters'(value, expected) {
+        expect:
+        DefaultValidator.removeEscapedEscapeCharacters(value) == expected
+
+        where:
+        value        | expected
+        "a \\\\ b"   | "a  b"
+        "a \\\\\\ b" | "a \\ b"
+        "a \\ b"     | "a \\ b"
+        "a \\ b\\"   | "a \\ b\\"
+        "a \\ b\\\\" | "a \\ b"
+    }
+
+
     def 'test validation of types'(value, type, expected, expectedErrors) {
         when:
         ConfigurationValue cval = new ConfigurationValue('bla', value.toString(), type)
 
         then:
-        cval.valid == expected
         cval.warnings == []
         cval.errors == expectedErrors
+        cval.valid == expected
 
         where:
         value      | type        | expected | expectedErrors
@@ -28,6 +42,7 @@ class DefaultValidatorSpec extends Specification {
         'b'        | 'float'     | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', 'float')]
         'c'        | 'double'    | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', 'double')]
         '( abc )'  | 'bashArray' | true     | []
+        '(abc)'    | 'bashArray' | true     | []
         'bla'      | 'bashArray' | true     | [] // Bash arrays can be empty. But then they actually may not contain whitespace
         'bla bla'  | 'bashArray' | true     | [] // Bash arrays need to be checked in a totally different way.
     }
@@ -37,17 +52,46 @@ class DefaultValidatorSpec extends Specification {
         ConfigurationValue cval = new ConfigurationValue('bla', value, type)
 
         then:
-        cval.valid == expected
         cval.warnings == expectedWarnings
-        cval.errors == []
+        cval.errors == expectedErrors
+        cval.valid == expected
 
         where:
         value                   | type     | expected | expectedWarnings                          | expectedErrors
+        // All are ok
         'abc${var}bcd${var}'    | 'string' | true     | []                                        | []
         'abc${var}bcd${var}def' | 'string' | true     | []                                        | []
-        'abc$'                  | 'string' | false    | [unattachedDollarCharacter.expand('bla')] | []
-        'abc${'                 | 'string' | false    | [unattachedDollarCharacter.expand('bla')] | []
-        'tr$ue'                 | 'string' | false    | [unattachedDollarCharacter.expand('bla')] | []
 
+        '\\$'                   | 'string' | true     | []                                      | []  //Escaped dollar
+        'abc\\$'                | 'string' | true     | []                                      | []  //Escaped dollar
+        'abc\\${'               | 'string' | true     | []                                      | []  //Escaped dollar with open brace
+        'a\\${b}c'              | 'string' | true     | []                                      | []  //Escaped dollar with complete braces
+
+        // Not ok
+        'abc$'                  | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
+        'tr$ue'                 | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
+        '$'                     | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
+        'abc$\\{'               | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
+    }
+
+    def "test check for proper variable usage definition"() {
+        when:
+        ConfigurationValue cval = new ConfigurationValue('bla', value, type)
+
+        then:
+        cval.warnings == expectedWarnings
+        cval.errors == expectedErrors
+        cval.valid == expected
+
+        where:
+        value              | type     | expected | expectedWarnings                           | expectedErrors
+        'abc${var}'        | "string" | true     | []                                         | []
+        'abc\\${var}'      | "string" | true     | []                                         | []
+        'abc${var}v${var}' | "string" | true     | []                                         | []
+        '\\${c}'           | 'string' | true     | []                                         | []
+        '\\${c'            | 'string' | true     | []                                         | []
+        'abc${${var}}'     | "string" | false    | [inproperVariableExpression.expand('bla')] | []
+        'abc${'            | 'string' | false    | [inproperVariableExpression.expand('bla')] | []
+        'ab${c'            | 'string' | false    | [inproperVariableExpression.expand('bla')] | []
     }
 }

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -1,9 +1,16 @@
 package de.dkfz.roddy.config.validation
 
+import de.dkfz.roddy.config.ConfigurationConstants
 import de.dkfz.roddy.config.ConfigurationIssue
 import de.dkfz.roddy.config.ConfigurationValue
 import spock.lang.Specification
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BOOLEAN
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.*
 
 class DefaultValidatorSpec extends Specification {
@@ -32,19 +39,19 @@ class DefaultValidatorSpec extends Specification {
         cval.valid == expected
 
         where:
-        value      | type        | expected | expectedErrors
-        1          | 'integer'   | true     | []
-        1.0f       | 'float'     | true     | []
-        1.0        | 'double'    | true     | []
-        true       | 'boolean'   | true     | []
-        'badvalue' | 'boolean'   | true     | [] // Validates always!
-        'a'        | 'integer'   | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', 'integer')]
-        'b'        | 'float'     | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', 'float')]
-        'c'        | 'double'    | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', 'double')]
-        '( abc )'  | 'bashArray' | true     | []
-        '(abc)'    | 'bashArray' | true     | []
-        'bla'      | 'bashArray' | true     | [] // Bash arrays can be empty. But then they actually may not contain whitespace
-        'bla bla'  | 'bashArray' | true     | [] // Bash arrays need to be checked in a totally different way.
+        value      | type                   | expected | expectedErrors
+        1          | CVALUE_TYPE_INTEGER    | true     | []
+        1.0f       | CVALUE_TYPE_FLOAT      | true     | []
+        1.0        | CVALUE_TYPE_DOUBLE     | true     | []
+        true       | CVALUE_TYPE_BOOLEAN    | true     | []
+        'badvalue' | CVALUE_TYPE_BOOLEAN    | true     | [] // Validates always!
+        'a'        | CVALUE_TYPE_INTEGER    | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', CVALUE_TYPE_INTEGER)]
+        'b'        | CVALUE_TYPE_FLOAT      | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', CVALUE_TYPE_FLOAT)]
+        'c'        | CVALUE_TYPE_DOUBLE     | false    | [new ConfigurationIssue(valueAndTypeMismatch, 'bla', CVALUE_TYPE_DOUBLE)]
+        '( abc )'  | CVALUE_TYPE_BASH_ARRAY | true     | []
+        '(abc)'    | CVALUE_TYPE_BASH_ARRAY | true     | []
+        'bla'      | CVALUE_TYPE_BASH_ARRAY | true     | [] // Bash arrays can be empty. But then they actually may not contain whitespace
+        'bla bla'  | CVALUE_TYPE_BASH_ARRAY | true     | [] // Bash arrays need to be checked in a totally different way.
     }
 
     def 'test check proper dollar sign usage in variables'(value, type, expected, expectedWarnings, expectedErrors) {
@@ -57,21 +64,21 @@ class DefaultValidatorSpec extends Specification {
         cval.valid == expected
 
         where:
-        value                   | type     | expected | expectedWarnings                          | expectedErrors
+        value                   | type               | expected | expectedWarnings                        | expectedErrors
         // All are ok
-        'abc${var}bcd${var}'    | 'string' | true     | []                                        | []
-        'abc${var}bcd${var}def' | 'string' | true     | []                                        | []
+        'abc${var}bcd${var}'    | CVALUE_TYPE_STRING | true     | []                                      | []
+        'abc${var}bcd${var}def' | CVALUE_TYPE_STRING | true     | []                                      | []
 
-        '\\$'                   | 'string' | true     | []                                      | []  //Escaped dollar
-        'abc\\$'                | 'string' | true     | []                                      | []  //Escaped dollar
-        'abc\\${'               | 'string' | true     | []                                      | []  //Escaped dollar with open brace
-        'a\\${b}c'              | 'string' | true     | []                                      | []  //Escaped dollar with complete braces
+        '\\$'                   | CVALUE_TYPE_STRING | true     | []                                      | []  //Escaped dollar
+        'abc\\$'                | CVALUE_TYPE_STRING | true     | []                                      | []  //Escaped dollar
+        'abc\\${'               | CVALUE_TYPE_STRING | true     | []                                      | []  //Escaped dollar with open brace
+        'a\\${b}c'              | CVALUE_TYPE_STRING | true     | []                                      | []  //Escaped dollar with complete braces
 
         // Not ok
-        'abc$'                  | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
-        'tr$ue'                 | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
-        '$'                     | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
-        'abc$\\{'               | 'string' | false    | [detachedDollarCharacter.expand('bla')] | []
+        'abc$'                  | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
+        'tr$ue'                 | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
+        '$'                     | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
+        'abc$\\{'               | CVALUE_TYPE_STRING | false    | [detachedDollarCharacter.expand('bla')] | []
     }
 
     def "test check for proper variable usage definition"() {
@@ -84,14 +91,14 @@ class DefaultValidatorSpec extends Specification {
         cval.valid == expected
 
         where:
-        value              | type     | expected | expectedWarnings                           | expectedErrors
-        'abc${var}'        | "string" | true     | []                                         | []
-        'abc\\${var}'      | "string" | true     | []                                         | []
-        'abc${var}v${var}' | "string" | true     | []                                         | []
-        '\\${c}'           | 'string' | true     | []                                         | []
-        '\\${c'            | 'string' | true     | []                                         | []
-        'abc${${var}}'     | "string" | false    | [inproperVariableExpression.expand('bla')] | []
-        'abc${'            | 'string' | false    | [inproperVariableExpression.expand('bla')] | []
-        'ab${c'            | 'string' | false    | [inproperVariableExpression.expand('bla')] | []
+        value              | type               | expected | expectedWarnings                           | expectedErrors
+        'abc${var}'        | CVALUE_TYPE_STRING | true     | []                                         | []
+        'abc\\${var}'      | CVALUE_TYPE_STRING | true     | []                                         | []
+        'abc${var}v${var}' | CVALUE_TYPE_STRING | true     | []                                         | []
+        '\\${c}'           | CVALUE_TYPE_STRING | true     | []                                         | []
+        '\\${c'            | CVALUE_TYPE_STRING | true     | []                                         | []
+        'abc${${var}}'     | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla')] | []
+        'abc${'            | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla')] | []
+        'ab${c'            | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla')] | []
     }
 }

--- a/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
@@ -1,19 +1,19 @@
 package de.dkfz.roddy.core
 
-import de.dkfz.roddy.config.ConfigurationIssue
+
 import spock.lang.Shared
 import spock.lang.Specification
 
-import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.unattachedDollarCharacter
+import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.detachedDollarCharacter
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.valueAndTypeMismatch
 
 class AnalysisSpec extends Specification {
 
     @Shared
-    static def valA = unattachedDollarCharacter.expand("a")
+    static def valA = detachedDollarCharacter.expand("a")
 
     @Shared
-    static def valB = unattachedDollarCharacter.expand("b")
+    static def valB = detachedDollarCharacter.expand("b")
 
     @Shared
     static def valC = valueAndTypeMismatch.expand("a", "b")

--- a/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.core
 
 

--- a/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionSpecification.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionSpecification.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.core
 
 import de.dkfz.roddy.config.Configuration

--- a/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.core
 
 import de.dkfz.roddy.RunMode

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
@@ -8,6 +8,7 @@ package de.dkfz.roddy.core
 
 import de.dkfz.roddy.Constants
 import de.dkfz.roddy.Roddy
+import de.dkfz.roddy.SystemProperties
 import de.dkfz.roddy.config.*
 import de.dkfz.roddy.execution.io.ExecutionResult
 import de.dkfz.roddy.execution.io.NoNoExecutionService
@@ -152,11 +153,11 @@ class ContextResource extends ExternalResource {
 
             final DataSet dataSet = new DataSet(analysis, "TEST_PID", getTestOutputDirectory("TEST_PID"))
 
-            result = new ExecutionContext(System.getProperty("user.name"), analysis, dataSet, ExecutionContextLevel.UNSET,
+            result = new ExecutionContext(SystemProperties.getUserName(), analysis, dataSet, ExecutionContextLevel.UNSET,
                     testOutputDirectory, testInputDirectory, testExecutionDirectory, System.nanoTime())
 
         } else {
-            result = new ExecutionContext(System.getProperty("user.name"), null, null, ExecutionContextLevel.UNSET,
+            result = new ExecutionContext(SystemProperties.getUserName(), null, null, ExecutionContextLevel.UNSET,
                     testOutputDirectory, testInputDirectory, testExecutionDirectory, System.nanoTime())
         }
         return result

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
@@ -1,12 +1,16 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core
 
+import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.config.Configuration
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.knowledge.files.BaseFile
 import groovy.transform.CompileStatic
 import org.junit.Rule
@@ -14,9 +18,14 @@ import org.junit.Test
 
 @CompileStatic
 class ContextResourceTest {
-    
+
     @Rule
     public ContextResource contextResource = new ContextResource()
+
+    static {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
+    }
 
     @Test
     void testGetTestBaseDirectory() {

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriterTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
@@ -6,13 +6,8 @@
 
 package de.dkfz.roddy.core
 
-import de.dkfz.roddy.config.AnalysisConfiguration
-import de.dkfz.roddy.config.Configuration
-import de.dkfz.roddy.config.ConfigurationError
-import de.dkfz.roddy.config.PreloadedConfiguration
-import de.dkfz.roddy.config.ProjectConfiguration
-import de.dkfz.roddy.config.ResourceSet
-import de.dkfz.roddy.config.ResourceSetSize
+import de.dkfz.roddy.SystemProperties
+import de.dkfz.roddy.config.*
 import de.dkfz.roddy.execution.io.ExecutionResult
 import de.dkfz.roddy.execution.io.NoNoExecutionService
 import de.dkfz.roddy.execution.jobs.*
@@ -122,11 +117,11 @@ public class MockupExecutionContextBuilder {
 
             final DataSet dataSet = new DataSet(analysis, "TEST_PID", getTestOutputDirectory("TEST_PID"))
 
-            return new ExecutionContext(System.getProperty("user.name"), analysis, dataSet, ExecutionContextLevel.UNSET,
+            return new ExecutionContext(SystemProperties.getUserName(), analysis, dataSet, ExecutionContextLevel.UNSET,
                     testOutputDirectory, testInputDirectory, testExecutionDirectory, System.nanoTime())
 
         } else {
-            return new ExecutionContext(System.getProperty("user.name"), null, null, ExecutionContextLevel.UNSET,
+            return new ExecutionContext(SystemProperties.getUserName(), null, null, ExecutionContextLevel.UNSET,
                                         testOutputDirectory, testInputDirectory, testExecutionDirectory, System.nanoTime())
         }
     }

--- a/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/RuntimeServiceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/RuntimeServiceTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTestInlineScript.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTestInlineScript.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BaseMetadataTableTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BaseMetadataTableTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
@@ -23,8 +23,9 @@ import org.junit.Test
 import org.junit.rules.ExpectedException
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
+import java.util.Arrays
 
+import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING;
 import static org.junit.Assert.*;
 
 /**
@@ -48,12 +49,12 @@ public class MetadataTableFactoryTest {
         RecursiveOverridableMapContainerForConfigurationValues configurationValues = configuration.getConfigurationValues();
 
         // Add columns
-        configurationValues.add(new ConfigurationValue(configuration, "datasetCol", "PID", "string", "", ["mandatory"] as List<String>));
-        configurationValues.add(new ConfigurationValue(configuration, "fileCol", "File", "string", "", ["mandatory"] as List<String>));
-        configurationValues.add(new ConfigurationValue(configuration, "rumpleCol", "Rumple", "string", "", [] as List<String>));
+        configurationValues.add(new ConfigurationValue(configuration, "datasetCol", "PID", CVALUE_TYPE_STRING, "", ["mandatory"] as List<String>));
+        configurationValues.add(new ConfigurationValue(configuration, "fileCol", "File", CVALUE_TYPE_STRING, "", ["mandatory"] as List<String>));
+        configurationValues.add(new ConfigurationValue(configuration, "rumpleCol", "Rumple", CVALUE_TYPE_STRING, "", [] as List<String>));
 
         // Add list of used columns
-        configurationValues.add(new ConfigurationValue(configuration, "metadataTableColumnIDs", "datasetCol,fileCol,rumpleCol", "string", "", [] as List<String>));
+        configurationValues.add(new ConfigurationValue(configuration, "metadataTableColumnIDs", "datasetCol,fileCol,rumpleCol", CVALUE_TYPE_STRING, "", [] as List<String>));
 
         // Setup Roddy to allow --usemetadatatable
         def field = Roddy.getDeclaredField("commandLineCall")

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetSpecification.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetSpecification.groovy
@@ -25,18 +25,36 @@ class BashCommandSetSpecification extends Specification {
     @Shared
     File tmpc = new File("/tmp/c")
 
+    def "test getListFilesInDirectoryCommand without filters"(File dir, expected) {
+        expect:
+        b.getListFilesInDirectoryCommand(dir) == expected
+
+        where:
+        dir  | expected
+        tmpa | 'find -L /tmp/a -type f -maxdepth 1'
+    }
+
+    def "test getListFilesInDirectoryCommand with filters"(File dir, List<String> filters, expected) {
+        expect:
+        b.getListFilesInDirectoryCommand(dir, filters) == expected
+
+        where:
+        dir  | filters             | expected
+        tmpa | ["a", "??b", "*.c"] | 'ls -lL -d /tmp/a/a /tmp/a/??b /tmp/a/*.c 2> /dev/null | grep -v "^d" | awk \'{ print $9 }\' | uniq'
+    }
+
     def testGetListFullDirectoryContentRecursivelyCommand(File directory, int depth, FileType selectedType, boolean complexList, String result) {
         expect:
         b.getListFullDirectoryContentRecursivelyCommand(directory, depth, selectedType, complexList) == result
 
         where:
         directory | depth | selectedType | complexList | result
-        tmpa      | -1    | ANY          | false       | 'find "/tmp/a"'
-        tmpa      | -1    | FILES        | false       | 'find "/tmp/a" -type f'
-        tmpa      | -1    | DIRECTORIES  | true        | 'find "/tmp/a" -type d -ls'
-        tmpa      | 0     | ANY          | false       | 'find "/tmp/a"'
-        tmpa      | 1     | FILES        | false       | 'find "/tmp/a" -maxdepth 1 -type f'
-        tmpa      | 2     | DIRECTORIES  | true        | 'find "/tmp/a" -maxdepth 2 -type d -ls'
+        tmpa      | -1    | ANY          | false       | 'find -L "/tmp/a"'
+        tmpa      | -1    | FILES        | false       | 'find -L "/tmp/a" -type f'
+        tmpa      | -1    | DIRECTORIES  | true        | 'find -L "/tmp/a" -type d -ls'
+        tmpa      | 0     | ANY          | false       | 'find -L "/tmp/a"'
+        tmpa      | 1     | FILES        | false       | 'find -L "/tmp/a" -maxdepth 1 -type f'
+        tmpa      | 2     | DIRECTORIES  | true        | 'find -L "/tmp/a" -maxdepth 2 -type d -ls'
     }
 
     def testGetListFullDirectoriesContentRecursivelyCommand(List<File> directories, List<Integer> depth, FileType selectedType, boolean complexList, String result) {
@@ -45,10 +63,10 @@ class BashCommandSetSpecification extends Specification {
 
         where:
         directories  | depth  | selectedType | complexList | result
-        [tmpa]       | [-1]   | ANY          | false       | 'find "/tmp/a"'
-        [tmpa, tmpa] | [0, 0] | ANY          | false       | 'find "/tmp/a"'
-        [tmpa, tmpb] | [1, 1] | FILES        | false       | 'find "/tmp/a" -maxdepth 1 -type f && find "/tmp/b" -maxdepth 1 -type f'
-        [tmpb, tmpc] | [2, 2] | DIRECTORIES  | true        | 'find "/tmp/b" -maxdepth 2 -type d -ls && find "/tmp/c" -maxdepth 2 -type d -ls'
+        [tmpa]       | [-1]   | ANY          | false       | 'find -L "/tmp/a"'
+        [tmpa, tmpa] | [0, 0] | ANY          | false       | 'find -L "/tmp/a"'
+        [tmpa, tmpb] | [1, 1] | FILES        | false       | 'find -L "/tmp/a" -maxdepth 1 -type f && find -L "/tmp/b" -maxdepth 1 -type f'
+        [tmpb, tmpc] | [2, 2] | DIRECTORIES  | true        | 'find -L "/tmp/b" -maxdepth 2 -type d -ls && find -L "/tmp/c" -maxdepth 2 -type d -ls'
     }
 
     def testGetFindFilesUsingWildcardsCommand(File baseFolder, String wildcards, String result) {

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
@@ -6,37 +6,48 @@
 
 package de.dkfz.roddy.execution.jobs
 
+import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.config.TestFileStageSettings
-import de.dkfz.roddy.core.ContextResource;
+import de.dkfz.roddy.core.ContextResource
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.knowledge.files.BaseFile
 import groovy.transform.CompileStatic
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
 
 /**
  * Created by heinold on 10.01.17.
  */
 @CompileStatic
-public class BEJobTest {
+class BEJobTest {
 
     @Rule
     final public ContextResource contextResource = new ContextResource()
 
-    @CompileStatic
-    public static class TestFile extends BaseFile {
+    @BeforeClass
+    static void setup() {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
+    }
 
-        public TestFile(BaseFile.ConstructionHelperForSourceFiles helper) {
-            super(helper);
+    @CompileStatic
+    static class TestFile extends BaseFile {
+
+        TestFile(BaseFile.ConstructionHelperForSourceFiles helper) {
+            super(helper)
         }
 
-        public File getPath() {
-            return new File('/a/test/${jobParameter,name=\"abc\"}/${jobParameter,name=\"def\"}/text.txt');
+        File getPath() {
+            return new File('/a/test/${jobParameter,name=\"abc\"}/${jobParameter,name=\"def\"}/text.txt')
         }
 
     }
 
     @Test
-    public void replaceParametersInFilePath() throws Exception {
+    void replaceParametersInFilePath() throws Exception {
         BaseFile bf = new TestFile(new BaseFile.ConstructionHelperForSourceFiles(new File("/invalid"),
                 contextResource.createSimpleContext(BEJobTest.name), new TestFileStageSettings<>(), null))
         def parm = ["abc": "avalue",

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/CommandTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/CommandTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
@@ -6,10 +6,15 @@
 
 package de.dkfz.roddy.execution.jobs
 
+import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.config.TestFileStageSettings
-import de.dkfz.roddy.core.ContextResource;
+import de.dkfz.roddy.core.ContextResource
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider;
 import de.dkfz.roddy.knowledge.files.BaseFile
 import groovy.transform.CompileStatic
+import org.junit.BeforeClass
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -21,6 +26,12 @@ class JobTest {
 
     @Rule
     final public ContextResource contextResource = new ContextResource()
+
+    @BeforeClass
+    static void setup() {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
+    }
 
     @CompileStatic
     static class TestFile extends BaseFile {

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManagerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManagerTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs.cluster.pbs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManagerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManagerTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs.cluster.sge

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflowTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflowTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows
 
 import de.dkfz.roddy.Constants

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflowTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflowTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.brawlworkflows

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
@@ -6,10 +6,14 @@
 
 package de.dkfz.roddy.knowledge.files
 
+import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.config.*
 import de.dkfz.roddy.config.loader.ConfigurationFactory
 import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.core.ContextResource
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.execution.jobs.BEJobResult
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.plugins.LibrariesFactoryTest
@@ -64,6 +68,8 @@ class BaseFileTest {
 
     @Before
     void setupBaseFileTests() {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
         //Setup plugins and default configuration folders
         LibrariesFactory.initializeFactory(true)
         LibrariesFactory.getInstance().loadLibraries(LibrariesFactory.buildupPluginQueue(LibrariesFactoryTest.callLoadMapOfAvailablePlugins(), "DefaultPlugin").values() as List)

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.files
 
 import de.dkfz.roddy.core.ContextResource

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/methods/GenericMethodTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/methods/GenericMethodTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.methods

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/BuildInfoFileHelperTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/BuildInfoFileHelperTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryRegexMethodTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryRegexMethodTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/NativePluginInfoTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/NativePluginInfoTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoMapTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoMapTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins;

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/tools/CollectionHelperMethodsTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/tools/CollectionHelperMethodsTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/RoddyCore/test/src/de/dkfz/roddy/tools/RuntimeToolsTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/tools/RuntimeToolsTest.groovy
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ configurations.all {
 dependencies {
     compile 'com.github.theroddywms:RoddyToolLib:2.0.0'         // MIT
     // compile 'com.github.theroddywms:RoddyToolLib:master-SNAPSHOT'    // MIT
-    compile 'com.github.theroddywms:BatchEuphoria:0.0.5'        // MIT
+    compile 'com.github.theroddywms:BatchEuphoria:0.0.6'        // MIT
     // compile 'com.github.theroddywms:BatchEuphoria:master-SNAPSHOT'   // MIT
     compile 'org.codehaus.groovy:groovy-all:2.4.9'              // Apache 2.0
 

--- a/dist/bin/develop/helperScripts/IncreaseAndSetBuildVersion.groovy
+++ b/dist/bin/develop/helperScripts/IncreaseAndSetBuildVersion.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 // Update build version and date in Constants.java

--- a/dist/bin/develop/helperScripts/addChangelistVersionTag.groovy
+++ b/dist/bin/develop/helperScripts/addChangelistVersionTag.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 /**

--- a/dist/bin/develop/helperScripts/convertCommandLineConfigToXML.groovy
+++ b/dist/bin/develop/helperScripts/convertCommandLineConfigToXML.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 /**

--- a/dist/bin/develop/helperScripts/findPluginFolders.groovy
+++ b/dist/bin/develop/helperScripts/findPluginFolders.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 // This script is used to extract find all plugin base folders.

--- a/dist/bin/develop/helperScripts/findPluginLibraries.groovy
+++ b/dist/bin/develop/helperScripts/findPluginLibraries.groovy
@@ -3,7 +3,7 @@ import java.nio.file.AccessDeniedException
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 

--- a/dist/bin/develop/helperScripts/prepareProjectConfiguration.groovy
+++ b/dist/bin/develop/helperScripts/prepareProjectConfiguration.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 import de.dkfz.roddy.client.RoddyStartupOptions

--- a/dist/bin/develop/helperScripts/skeletonProject_extended.xml
+++ b/dist/bin/develop/helperScripts/skeletonProject_extended.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project'

--- a/dist/bin/develop/helperScripts/skeletonProject_minimal.xml
+++ b/dist/bin/develop/helperScripts/skeletonProject_minimal.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project'

--- a/dist/bin/develop/testFiles/projectsTest.xml
+++ b/dist/bin/develop/testFiles/projectsTest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='TestProjectForUnitTests' description='Like the name says' runtimeServiceClass='de.dkfz.roddy.knowledge.examples.SimpleRuntimeService' imports="testProjectImportLvl0">

--- a/dist/bin/develop/testFiles/projectsTestImportLvl0.xml
+++ b/dist/bin/develop/testFiles/projectsTestImportLvl0.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='testProjectImportLvl0' description='Test project' runtimeServiceClass='de.dkfz.roddy.knowledge.examples.SimpleRuntimeService' imports="testProjectImportLvl1">

--- a/dist/bin/develop/testFiles/projectsTestImportLvl1.xml
+++ b/dist/bin/develop/testFiles/projectsTestImportLvl1.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='testProjectImportLvl1' description='Test project' runtimeServiceClass='de.dkfz.roddy.knowledge.examples.SimpleRuntimeService' imports="">

--- a/dist/plugins/Template/resources/configurationFiles/analysisTemplate.xml
+++ b/dist/plugins/Template/resources/configurationFiles/analysisTemplate.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='templateAnalysis' description='A template xml for java workflows.'

--- a/dist/plugins/Template/resources/configurationFiles/analysisTemplateBrawl.xml
+++ b/dist/plugins/Template/resources/configurationFiles/analysisTemplateBrawl.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='templateNativeAnalysis' description='A template for brawl workflows.'

--- a/dist/plugins/Template/resources/configurationFiles/analysisTemplateNative.xml
+++ b/dist/plugins/Template/resources/configurationFiles/analysisTemplateNative.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='templateNativeAnalysis' description='A template for native workflows.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyCValues.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyCValues.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysisFaultyCValues' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyTools.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyTools.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysisFaultyTools' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTest.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysis' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCohortWorkflow.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCohortWorkflow.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2018 DKFZ - ODCF
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='simpleCohortWorkflowAnalysis'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCorrectExecution.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCorrectExecution.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testCorrectExecutionAnalysis' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestFaultyPatterns.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestFaultyPatterns.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysisFaultyPatterns' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/FileWithChildren.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/FileWithChildren.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleCohortWorkflow.groovy
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleCohortWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStage.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStage.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStageSettings.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStageSettings.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleRuntimeService.groovy
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleRuntimeService.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleTestTextFile.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleTestTextFile.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflow.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflow.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflowWithCorrectExecution.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflowWithCorrectExecution.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestPlugin.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestPlugin.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestWorkflow.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestWorkflow.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithoutJarFile/resources/configurationFiles/analysisTestNative.xml
+++ b/dist/plugins/TestPluginWithoutJarFile/resources/configurationFiles/analysisTestNative.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='analysis'

--- a/docs/config/xmlConfigurationFiles.rst
+++ b/docs/config/xmlConfigurationFiles.rst
@@ -128,17 +128,31 @@ The configuration value itself is defined as a cvalue element. Each element can 
 * *type* - There exist several types for configuration values. The default value is string. Note, that the selection of
   the type will influence, how variables are interpreted and evaluated / converted.
 
-  - *string* will
+  - *string* accepts any value.
 
   - *int* will accept integer values only. E.g. 1, 2, 3 or 4.
 
-  - *float* will accept float values in differnt formats. E.g. 1.2f 1.2
+  - *float* will accept valid Java / Groovy float values. E.g. 1.2f 1.2
 
-  - *double* will accept
+  - *double* will accept valid Java / Groovy double values. E.g. 1.2 or 1.2E-3.
 
+  - *boolean* will evaluate true (preferred), y, j, t and 1 to true and false (preferred), n, f and 0 to false.
 
+  - *path* indicates, that the variable is a path or a part of a path.
 
-  - *boolean*
+Nice to know - Order of evaluation in Roddy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configuration values can be cast to their *type* by calling any of the methods *toBoolean()*,
+*toInt()*, *toFloat()*, *toDouble()*, *toString()* and *toFile()*.
+
+In contrast to the other methods, *toString()* and *toFile()* are quite complex methods which will resolve referenced
+variables. Moreover, *toFile()* also has a particular order in which configuration objects are used to achieve this:
+
+1. The first used configuration is normally the project configuration. So every referenced value stored in there will
+   become evaluated.
+2. The second used configuration is the analysis configuration and replaces USERNAME, USERGROUP, USERHOME, projectName and any other value attached to the analysis.
+3. The last used configuration is the one from the dataset, and replaces pid, PID, dataSet and DATASET.
 
 Special values
 ~~~~~~~~~~~~~~
@@ -151,7 +165,7 @@ and
 
 **Binaries** which look like BWA_BINARY, MBUFFER_BINARY, PYTHON_BINARY and so on.
 
-Run flags are always considered to be boolean and are e.g. used smartly in Brawl based workflows. Binary variables are or are supposed to be checked on workflow validation and startup in future versions. If you want to exchange a binary in a fast way or set a fixed binary for your scripts, it is also wise to store everything in configuration values. 
+Run flags are always considered to be boolean and are e.g. used in Brawl based workflows. Binary variables are or are supposed to be checked on workflow validation and startup in future versions. If you want to exchange a binary in a fast way or set a fixed binary for your scripts, it is also wise to store everything in configuration values.
 
 Tool entries and filename patterns
 ----------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,3 +6,35 @@ Indicated packet length ... too large
 
 The SSH library we currently use (sshj) does not work if during your login on the submission host (on which the e.g. qsub command is executed). Make
 sure during the login no output is generated, e.g. from your `$HOME/.profile`, `$HOME/.bashrc`, etc. files.
+
+When something wents wrong and Roddy returns an error code
+----------------------------------------------------------
+
+Roddy can exit with a range of exit codes which are:
+
+.. csv-table:: "Title"
+    :Header: "Exit code", "Description"
+    :Widths: 5, 20
+
+    "255", "You must call roddy from the right location! This is the folder where roddy.sh resides."
+    "254", "SystemExitException throw by GroovyServ. Only occurs when GroovyServ is enabled (not by default!)."
+    "253", "Command line was malformed, check your input and correct mistakes."
+    "252", "Execution requirements unfulfilled. Seems you are missing some applications, please install them or ask your administrator to do it for you."
+    "251", "Startup options could not be parsed. Check your command line."
+    "250", "Cannot find requested feature toggle file. Please make sure, that the required file exists."
+    "249", "Feature toggle is not known. There are only some available. If you are unsure about this, don't use them, if not necessary."
+    "248", "Unknown problem with proxy setup. Check your proxy settings."
+    "247", "scratchBaseDir is not defined in your application ini file. Please set it so that it matches your cluster settings."
+    "246", "The wrong job manager class is set in your application ini file. Please correct that."
+    "245", "Application properties file not found or loadable. Make sure, that the file exists."
+    "244", "Could not load the requested analysis. Look for typos or take another one."
+    "243", "Severe configuration errors occurred. Take a detailed look into the error messages and your configuration file,"
+    "242", "Unhandled exception. That is a bad one. Take a look at any error message and get in contact with us."
+    "241", "Unknown SSH host. Change the hostname, it is possibly wrong."
+    "240", "SSH setup is not valid. Please follow the instructions and check your application ini file."
+    "239", "Fatal error during SSH setup. Please contact us in this case."
+    
+    "100", "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255]."
+
+In any case, we try to provide you a good explanation about what happened wrong and how you can solve it. If you find
+the messages hard to understand, contact us.


### PR DESCRIPTION
ConfigurationValue:
- Fix the constructor for "double" values
- Add the replaceObsoleteVariableIdentifiers and call it from the
  constructor. The method replaces several older malformed values ($VAL)
  to their proper form (${VAL}).
- Remove the methods:
    * replaceString
    * toFile(), toFile(Map<String, String> replacements)
    * replaceConfigurationBasedValues
    * toString(List<String>)
- Consolidate and cleanup the methods toFile(Analysis, DataSet) and
  toFile(Analysis). The methods now use the normal variable replacement
  feature of Roddy instead of the removed replace method
- Make the field variableDetection static final
- Make toEvaluatedValue final and extend its argument list

Add a on-null-check to DefaultValidator.checkDollarSignUsage

Analysis:
- Clean up and groovyfy the class
- Change the getConfiguration method so that it will return a
  configuration which knows values like USERNAME and USERGROUP

DataSet now contains a getConfiguration method, which knows the
different variants of DATASET. For internal use only!

Add tests for variable replacement to ConfigurationValueSpec

Add ExecutionService and FileSystemAccessProvider init code to some
test classes