### PR TITLE
Add roddy test spec class and change all copyright notices

### DIFF
--- a/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/LSInputImpl.java
+++ b/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/LSInputImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package com.stackoverflow.questions.xmlvalidation;

--- a/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/LSInputImpl.java
+++ b/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/LSInputImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2015 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/ResourceResolver.java
+++ b/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/ResourceResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/ResourceResolver.java
+++ b/RoddyCore/src/com/stackoverflow/questions/xmlvalidation/ResourceResolver.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package com.stackoverflow.questions.xmlvalidation;

--- a/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;

--- a/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
@@ -40,7 +40,7 @@ enum AvailableFeatureToggles {
     ////////////////////////
     */
     @Deprecated
-    ForbidSubmissionOnRunning(false),
+    ForbidSubmissionOnRunning(true),
 
     @Deprecated
     BreakSubmissionOnError(false),

--- a/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/Constants.java
+++ b/RoddyCore/src/de/dkfz/roddy/Constants.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;

--- a/RoddyCore/src/de/dkfz/roddy/Constants.java
+++ b/RoddyCore/src/de/dkfz/roddy/Constants.java
@@ -41,6 +41,7 @@ public class Constants {
     public static final String APP_PROPERTY_SCRATCH_BASE_DIRECTORY = "scratchBaseDirectory";
     public static final String APP_PROPERTY_JOB_MANAGER_PASS_ENVIRONMENT = "jobManagerPassEnvironment";
     public static final String APP_PROPERTY_JOB_MANAGER_HOLDJOBS_ON_SUBMISSION = "jobManagerHoldJobsOnSubmission";
+    public static final String APP_PROPERTY_JOB_MANAGER_UPDATE_INTERVAL = "jobManagerUpdateInterval";
     public static final String APP_PROPERTY_BASE_ENVIRONMENT_SCRIPT = "baseEnvironmentScript";
 
     /////////////////////////
@@ -50,8 +51,6 @@ public class Constants {
     public static final String ERR_MSG_ONLY_ONE_JOB_ALLOWED = "A job object is not allowed to run several times.";
     public static final String ERR_MSG_WRONG_PARAMETER_COUNT = "You did not provide proper parameters, args.length = ";
     public static final String ERR_MSG_NO_APPLICATION_PROPERTY_FILE = "Configuration does not exist. Cannot start application.";
-
-//    public static final String APP_EXITCODE_
 
     /////////////////////////
     // Environment settings

--- a/RoddyCore/src/de/dkfz/roddy/Constants.java
+++ b/RoddyCore/src/de/dkfz/roddy/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
@@ -11,7 +11,7 @@ import groovy.transform.CompileStatic
 @CompileStatic
 enum ExitReasons {
 
-    wrongStartupLocation(255, "You must call roddy from the right location! (Base roddy folder where roddy.sh resides."),
+    wrongStartupLocation(255, "Wrong execution directory. Change to directory with roddy.sh before execution."),
     groovyServError(254, "SystemExitException throw by GroovyServ, will exit now."),
     malformedCommandLine(253, "Command line was malformed."),
     unfulfilledRequirements(252, "Execution requirements unfulfilled."),
@@ -22,7 +22,7 @@ enum ExitReasons {
     scratchDirNotConfigured(247, Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY + " is not defined."),
     wrongJobManagerClass(246, "Wrong job manager class."),
     appPropertiesFileNotFound(245, "Application properties file not found or loadable."),
-    analysisNotLoadable(244, "Could not load analysis"),
+    analysisNotLoadable(244, "Could not load analysis."),
     severeConfigurationErrors(243, "Severe configuration errors occurred."),
     unhandledException(242, "Unhandled exception."),
     unknownSSHHost(241, "SSH remote host could not be reached."),
@@ -31,7 +31,7 @@ enum ExitReasons {
     aJobHadAnError(238, "At least one job exited with an error."),
     waitForJobsFailedWithAnUnknownError(237, "Roddy.waitForJobs() failed with an unknown exception."),
 
-    wrongExitCodeUsed(100, "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255].")
+    wrongExitCodeUsed(100, "Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255].")
 
     final String message
 

--- a/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
+
+package de.dkfz.roddy
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+enum ExitReasons {
+
+    wrongStartupLocation(255, "You must call roddy from the right location! (Base roddy folder where roddy.sh resides."),
+    groovyServError(254, "SystemExitException throw by GroovyServ, will exit now."),
+    malformedCommandLine(253, "Command line was malformed."),
+    unfulfilledRequirements(252, "Execution requirements unfulfilled."),
+    unparseableStartupOptions(251, "Startup options could not be parsed."),
+    unknownFeatureToggleFile(250, "Cannot find requested feature toggle file."),
+    unknownFeatureToggle(249, "Feature toggle is not known."),
+    unknownProxyProblem(248, "Unknown problem with proxy setup."),
+    scratchDirNotConfigured(247, Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY + " is not defined."),
+    wrongJobManagerClass(246, "Wrong job manager class."),
+    appPropertiesFileNotFound(245, "Application properties file not found or loadable."),
+    analysisNotLoadable(244, "Could not load analysis"),
+    severeConfigurationErrors(243, "Severe configuration errors occurred."),
+    unhandledException(242, "Unhandled exception."),
+    unknownSSHHost(241, "SSH remote host could not be reached."),
+    invalidSSHConfig(240, "SSH setup is not valid."),
+    fatalSSHError(239, "Fatal error during SSH setup."),
+    aJobHadAnError(238, "At least one job exited with an error."),
+    waitForJobsFailedWithAnUnknownError(237, "Roddy.waitForJobs() failed with an unknown exception."),
+
+    wrongExitCodeUsed(100, "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255].")
+
+    final String message
+
+    final int code
+
+    ExitReasons(int code, String message) {
+        this.message = message
+        this.code = code
+    }
+}

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -26,7 +26,10 @@ import de.dkfz.roddy.execution.jobs.BatchEuphoriaJobManager;
 import de.dkfz.roddy.execution.jobs.JobManagerOptions;
 import de.dkfz.roddy.execution.jobs.direct.synchronousexecution.DirectSynchronousExecutionJobManager;
 import de.dkfz.roddy.plugins.LibrariesFactory;
-import de.dkfz.roddy.tools.*;
+import de.dkfz.roddy.tools.AppConfig;
+import de.dkfz.roddy.tools.LoggerWrapper;
+import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
+import de.dkfz.roddy.tools.RoddyIOHelperMethods;
 import groovy.transform.CompileStatic;
 
 import java.io.File;
@@ -37,6 +40,7 @@ import java.net.InetSocketAddress;
 import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.*;
 
 import static de.dkfz.roddy.RunMode.CLI;
@@ -201,7 +205,7 @@ public class Roddy {
             if (list == null || list.length != 1) {
                 System.out.println("You must call roddy from the right location! (Base roddy folder where roddy.sh resides). You used: '" +
                         applicationDirectory + "'");
-                System.exit(255);
+                System.exit(ExitReasons.wrongStartupLocation.getCode());
             }
 
             if (args.length == 0) {
@@ -222,7 +226,7 @@ public class Roddy {
             // we check for this particular exception by using its simple class name!
             if (!e.getClass().getName().endsWith("SystemExitException"))
                 e.printStackTrace();
-            exit(1);
+            exit(ExitReasons.groovyServError);
         }
     }
 
@@ -248,7 +252,7 @@ public class Roddy {
         CommandLineCall clc = new CommandLineCall(list);
         commandLineCall = clc;
         if (clc.isMalformed())
-            exit(1);
+            exit(ExitReasons.malformedCommandLine.getCode());
 
         // Initialize the logger with an initial setup. At this point we don't know about things like the logger settings
         // or the used app ini file. However, all the following methods rely on an existing valid logger setup.
@@ -258,7 +262,7 @@ public class Roddy {
 
         time("initial checks");
         if (!roddyExecutionRequirementsFulfilled())
-            exit(1);
+            exit(ExitReasons.unfulfilledRequirements.getCode());
 
         time("ftoggleini");
         initializeFeatureToggles();
@@ -281,7 +285,7 @@ public class Roddy {
         }
 
         if (!jobExecutionRequirementsFulfilled())
-            exit(1);
+            exit(ExitReasons.unfulfilledRequirements.getCode());
 
         time("initserv");
         parseRoddyStartupModeAndRun(clc);
@@ -425,8 +429,7 @@ public class Roddy {
                 }
             }
         } catch (RuntimeException e) {
-            logger.severe("Parsing startup options failed.");
-            exit(1);
+            exit(ExitReasons.unparseableStartupOptions);
         }
     }
 
@@ -436,8 +439,7 @@ public class Roddy {
             toggleIni = new File(commandLineCall.getOptionValue(RoddyStartupOptions.usefeaturetoggleconfig));
             logger.postSometimesInfo("Trying to load alternative feature toggles file: " + toggleIni);
             if (toggleIni == null || !toggleIni.exists()) {
-                logger.postAlwaysInfo("Cannot find requested toggle file.");
-                exit(1);
+                exit(ExitReasons.unknownFeatureToggleFile);
             }
 
         } else {
@@ -465,7 +467,7 @@ public class Roddy {
             String toggleNames = RoddyIOHelperMethods.joinArray(AvailableFeatureToggles.values(), "\n\t");
             logger.severe("Available toggle values are:\n\t" + toggleNames);
             if (isStrictModeEnabled())
-                exit(1);
+                exit(ExitReasons.unknownFeatureToggle.getCode());
         }
     }
 
@@ -571,7 +573,7 @@ public class Roddy {
                 l = ProxySelector.getDefault().select(new URI("http://codemirror.net"));
             } catch (URISyntaxException e) {
                 e.printStackTrace();
-                System.exit(1);
+                System.exit(ExitReasons.unknownProxyProblem.getCode());
             }
 
             if (l != null) {
@@ -618,8 +620,10 @@ public class Roddy {
         }
     }
 
-    /** Copy the scratchBaseDirectory value from the applicationProperties.ini into the configuration. Set the default value for RODDY_SCRATCH
-     *  to $scratchBaseDirectory/$RODDY_JOBID.
+    /**
+     * Copy the scratchBaseDirectory value from the applicationProperties.ini into the configuration. Set the default value for RODDY_SCRATCH
+     * to $scratchBaseDirectory/$RODDY_JOBID.
+     *
      * @return
      */
     private static void setScratchDirectory(RecursiveOverridableMapContainerForConfigurationValues configurationValues) {
@@ -631,7 +635,7 @@ public class Roddy {
                 propertyFilePath = Roddy.getPropertiesFilePath();
                 System.err.println(Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY +
                         " is not defined. Please add it to your application properties file: '" + propertyFilePath + "'");
-                System.exit(1);
+                System.exit(ExitReasons.scratchDirNotConfigured.getCode());
             } catch (FileNotFoundException e) {
                 // The file must have existed, because we are accessing the values in it.
                 scratchBaseDir = System.getenv("CURRENT_PWD");
@@ -642,7 +646,7 @@ public class Roddy {
 
         }
         configurationValues.add(new ConfigurationValue(Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY, scratchBaseDir));
-        String scratchDir = new File ("$" + Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY,
+        String scratchDir = new File("$" + Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY,
                 "$" + ConfigurationConstants.CVALUE_PLACEHOLDER_RODDY_JOBID_RAW).toString();
         configurationValues.add(new ConfigurationValue(CVALUE_PLACEHOLDER_RODDY_SCRATCH_RAW, scratchDir));
     }
@@ -708,7 +712,7 @@ public class Roddy {
                 available.append("\n\t" + acs.getClassName());
             }
             logger.severe("Could not find job manager class: " + jobManagerClassID + ", available are: " + available.toString() + "\nPlease set the jobManagerClass entry in your application ini file: " + getPropertiesFilePath().getAbsolutePath() + "");
-            exit(1);
+            exit(ExitReasons.wrongJobManagerClass.getCode());
         }
 
         /** Get the constructor which comes with no parameters */
@@ -716,10 +720,19 @@ public class Roddy {
         jobManager = (BatchEuphoriaJobManager) first.newInstance(ExecutionService.getInstance()
                 , JobManagerOptions.create()
                         .setCreateDaemon(true)
+                        .setUpdateInterval(Duration.ofSeconds(RoddyConversionHelperMethods.toInt(applicationProperties.getOrSetApplicationProperty(Constants.APP_PROPERTY_JOB_MANAGER_UPDATE_INTERVAL, "300", "integer"))))
                         .setPassEnvironment(applicationProperties.getOrSetBooleanApplicationProperty(Constants.APP_PROPERTY_JOB_MANAGER_PASS_ENVIRONMENT, false))
                         .setTrackOnlyStartedJobs(trackOnlyStartedJobs)
                         .setHoldJobIsEnabled(applicationProperties.getOrSetBooleanApplicationProperty(Constants.APP_PROPERTY_JOB_MANAGER_HOLDJOBS_ON_SUBMISSION, true))
                         .setUserIdForJobQueries(FileSystemAccessProvider.getInstance().callWhoAmI()).build());
+        jobManager.addUpdateDaemonListener((job, state) -> {
+            if (state.isSuccessful()) {
+                // Message for started jobs are also printed with println
+                System.out.println(String.format("  Job %s finished successfully.", job.getJobID()));
+            } else {
+                System.out.println(String.format("  Job %s finished with an error and state %s.", job.getJobID(), state.name()));
+            }
+        });
     }
 
     private static BatchEuphoriaJobManager jobManager;
@@ -750,8 +763,7 @@ public class Roddy {
             if (jobManager.executesWithoutJobSystem() && waitForJobsToFinish) {
                 exitCode = waitForJobs();
             } else {
-                // TODO: #167 (https://github.com/eilslabs/Roddy/issues/167)
-                exit(0);
+                exitCode = 0;
             }
         }
         exit(exitCode);
@@ -759,12 +771,17 @@ public class Roddy {
 
     private static int waitForJobs() {
         try {
-            Thread.sleep(15000); //Sleep at least 15 seconds to let any job scheduler handle things...
-            return jobManager.waitForJobsToFinish();
+            if (jobManager.isDaemonAlive()) {
+                logger.always("Waiting now, until all jobs are finished.");
+                Thread.sleep(5000); //Sleep at least 5 seconds to let any job scheduler handle things...
+                if (jobManager.waitForJobsToFinish()) {
+                    return ExitReasons.aJobHadAnError.getCode();
+                }
+            }
         } catch (Exception ex) {
-            return 250;
+            exit(ExitReasons.waitForJobsFailedWithAnUnknownError);
         }
-
+        return 0;
     }
 
     public static void exit() {
@@ -773,7 +790,14 @@ public class Roddy {
 
     public static void exit(int ecode) {
         Initializable.destroyAll();
-        System.exit(ecode <= 250 ? ecode : 250); //Exit codes should be in range from 0 .. 255
+        if (jobManager != null)
+            jobManager.stopUpdateDaemon();
+        System.exit(ecode <= 255 ? ecode : ExitReasons.wrongExitCodeUsed.getCode()); //Exit codes should be in range from 0 .. 255
+    }
+
+    public static void exit(ExitReasons reason) {
+        logger.severe(reason.getMessage());
+        exit(reason.getCode());
     }
 
     public static void loadPropertiesFile() {
@@ -782,7 +806,7 @@ public class Roddy {
             file = getPropertiesFilePath();
         } catch (FileNotFoundException e) {
             logger.postAlwaysInfo("Could not load the application properties file: " + e.getMessage() + ". Roddy will exit.");
-            exit(1);
+            exit(ExitReasons.appPropertiesFileNotFound.getCode());
         }
         logger.postAlwaysInfo("Loading properties file " + file.getAbsolutePath() + ".");
 

--- a/RoddyCore/src/de/dkfz/roddy/RunMode.java
+++ b/RoddyCore/src/de/dkfz/roddy/RunMode.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy;

--- a/RoddyCore/src/de/dkfz/roddy/RunMode.java
+++ b/RoddyCore/src/de/dkfz/roddy/RunMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client;

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client;

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/CommandLineCall.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/CommandLineCall.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/CommandLineCall.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/CommandLineCall.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -70,7 +70,7 @@ class RoddyCLIClient {
 
     static void startMode(CommandLineCall clc) {
         //TODO Convert to CommandLineCall
-        String[] args = clc.getArguments();
+        String[] args = clc.getArguments().toArray(new String[0]);
         switch (clc.startupMode) {
             case showreadme:
                 showReadme();
@@ -277,7 +277,7 @@ class RoddyCLIClient {
         Analysis analysis = new ProjectLoader().loadAnalysisAndProject(analysisID)
         if (!analysis) {
             logger.severe("Could not load analysis ${analysisID}")
-            Roddy.exit(1)
+            Roddy.exit(ExitReasons.analysisNotLoadable.getCode())
         }
         // This check only applies for analysis configuration files.
         checkConfigurationErrorsAndMaybePrintAndFail(analysis.configuration)
@@ -295,7 +295,7 @@ class RoddyCLIClient {
             } else {
                 logger.severe("There were configuration errors and Roddy will not start. Consider using --${RoddyStartupOptions.ignoreconfigurationerrors.name()} to ignore errors.")
                 System.err.println(errorText)
-                Roddy.exit(1)
+                Roddy.exit(ExitReasons.severeConfigurationErrors.code)
             }
         }
     }

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIDevClient.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIDevClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIDevClient.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIDevClient.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyDevelopmentOptionStep.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyDevelopmentOptionStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyDevelopmentOptionStep.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyDevelopmentOptionStep.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashColours.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashColours.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashColours.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashColours.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashFormatter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashFormatter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashFormatter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/BashFormatter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/ConsoleStringFormatter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/ConsoleStringFormatter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/ConsoleStringFormatter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/ConsoleStringFormatter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColorsFormatter.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColorsFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColorsFormatter.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColorsFormatter.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColours.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColours.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColours.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/clioutput/NoColours.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient.clioutput;

--- a/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy

--- a/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
@@ -41,7 +41,7 @@ public class RoddyNetworkSubmissionServer {
 
         } catch (Exception ex) {
             System.out.println(ex);
-            System.exit(1);
+            System.exit(ExitReasons.unhandledException.code);
         }
 
         //Just exit without an error

--- a/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnection.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnection.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnection.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnection.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterface.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterface.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterface.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementation.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementation.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementation.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementation.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIServer.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIServer.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/rmiclient/RoddyRMIServer.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisImportKillSwitch.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisImportKillSwitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisImportKillSwitch.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisImportKillSwitch.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/Configuration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Configuration.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/Configuration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Configuration.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationConstants.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
 import groovy.transform.CompileStatic

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.config
 

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueHelper.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ContainerParent.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ContainerParent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ContainerParent.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ContainerParent.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/DerivedFromFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/DerivedFromFilenamePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/DerivedFromFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/DerivedFromFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/EmptyResourceSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/EmptyResourceSet.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/EmptyResourceSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/EmptyResourceSet.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/EnumerationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/EnumerationValue.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/EnumerationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/EnumerationValue.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/FileStageFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FileStageFilenamePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/FileStageFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FileStageFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternDependency.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternDependency.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternDependency.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/OnMethodFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnMethodFilenamePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/OnMethodFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnMethodFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/OnScriptParameterFilenamePattern.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnScriptParameterFilenamePattern.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/OnScriptParameterFilenamePattern.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnScriptParameterFilenamePattern.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/OnToolFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnToolFilenamePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/OnToolFilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/OnToolFilenamePattern.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/PreloadedConfiguration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/PreloadedConfiguration.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/PreloadedConfiguration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/PreloadedConfiguration.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ProjectConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ProjectConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ProjectConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ProjectConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config;
 
 import de.dkfz.roddy.RunMode;

--- a/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
@@ -64,6 +64,12 @@ public class RoddyAppConfig extends AppConfig {
             case CVALUE_TYPE_STRING:
                 value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
                 break;
+            case CVALUE_TYPE_INTEGER:
+                if (!RoddyConversionHelperMethods.isInteger(defaultValue)) {
+                    throw new ConfigurationError(String.format("The value for '%s' is not of type '%s'", pName, type), pName);
+                }
+                value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
+                break;
             case CVALUE_TYPE_PATH:
                 value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
                 break;

--- a/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.config;
 

--- a/RoddyCore/src/de/dkfz/roddy/config/TestAnalysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/TestAnalysis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/TestAnalysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/TestAnalysis.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileGroupParameter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileGroupParameter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileGroupParameter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileGroupParameter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameterCheckCondition.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameterCheckCondition.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameterCheckCondition.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolFileParameterCheckCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolStringParameter.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolStringParameter.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolStringParameter.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolStringParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolTupleParameter.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolTupleParameter.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolTupleParameter.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolTupleParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/UnknownConfigurationFileTypeException.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/UnknownConfigurationFileTypeException.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config;

--- a/RoddyCore/src/de/dkfz/roddy/config/UnknownConfigurationFileTypeException.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/UnknownConfigurationFileTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/ConfigurationConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/ConfigurationConverter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters;

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/ConfigurationConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/ConfigurationConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/XMLConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/XMLConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/XMLConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/XMLConverter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/YAMLConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/YAMLConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/YAMLConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/YAMLConverter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoaderException.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoaderException.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.loader

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/BashScriptChecker.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/BashScriptChecker.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/BashScriptChecker.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/BashScriptChecker.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/BashValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/BashValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/BashValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/BashValidator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidationError.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidationError.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidationError.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValidator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueCombinationValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueCombinationValidator.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueCombinationValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueCombinationValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueValidator.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ConfigurationValueValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/FileSystemValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/FileSystemValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/FileSystemValidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/FileSystemValidator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/Invalidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/Invalidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/Invalidator.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/Invalidator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptChecker.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptChecker.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptChecker.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation;

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptValidator.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ScriptValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/WholeConfigurationValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/WholeConfigurationValidator.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/WholeConfigurationValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/WholeConfigurationValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/XSDValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/XSDValidator.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.validation

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/XSDValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/XSDValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
@@ -103,6 +103,19 @@ class Analysis {
 
     private ContextConfiguration _analysisConfiguration = null
 
+    /**
+     * Tests using analysis objects will need to implement the following:
+     *
+     * static {
+     *   ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+     *   FileSystemAccessProvider.initializeProvider(true)
+     * }
+     *
+     * If they don't, tests will fail with a NullPointerException!
+     *
+     * Alternatively, you could use the RoddyTestSpec class as a base for Spock tests.
+     * @return
+     */
     AnalysisConfiguration getConfiguration() {
         if (_analysisConfiguration == null) {
             _analysisConfiguration = new ContextConfiguration((AnalysisConfiguration) this.configuration, (ProjectConfiguration) this.project.getConfiguration())

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
@@ -260,10 +260,7 @@ class Analysis {
     }
 
     private boolean canStartJobs(DataSet ds) {
-        if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning)) {
-            throw new RuntimeException("Feature toggle forbidSubmissionOnRunning is currently unsupported due to lack of use by users. If you need it contact the developers.")
-        }
-        return !Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning) || !hasKnownRunningJobs(ds)
+        return !Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning) || !hasKnownRunningJobs(ds);
     }
 
     boolean hasKnownRunningJobs(DataSet ds) {

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformation.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformation.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformation.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformationListener.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformationListener.java
@@ -1,5 +1,5 @@
 ///*
-// * Copyright (c) 2016 eilslabs.
+// * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
 // *
 // * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
 // */

--- a/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformationListener.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/AnalysisProcessingInformationListener.java
@@ -1,7 +1,7 @@
 ///*
 // * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
 // *
-// * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+// * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
 // */
 //
 //package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtension.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/CohortDataSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/CohortDataSet.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/CohortDataSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/CohortDataSet.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/DataSet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/DataSetListener.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/DataSetListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/DataSetListener.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/DataSetListener.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextError.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextError.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextError.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextLevel.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextLevel.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextLevel.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextSubLevel.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextSubLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextSubLevel.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContextSubLevel.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/Initializable.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Initializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/Initializable.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Initializable.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/LibraryEntry.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/LibraryEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/LibraryEntry.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/LibraryEntry.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ProcessingFlag.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProcessingFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ProcessingFlag.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProcessingFlag.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/Project.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/Project.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Project.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core;

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -16,6 +16,8 @@ import de.dkfz.roddy.config.loader.ConfigurationFactory
 import de.dkfz.roddy.config.loader.ConfigurationLoaderException
 import de.dkfz.roddy.config.validation.XSDValidator
 import de.dkfz.roddy.execution.io.MetadataTableFactory
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import de.dkfz.roddy.plugins.ClassLoaderHelper
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.plugins.PluginInfo
 import de.dkfz.roddy.plugins.PluginInfoMap
@@ -386,6 +388,13 @@ class ProjectLoader {
 
         if (analysis == null)
             throw new ProjectLoaderException("Could not load analysis ${analysisID}")
+
+        try {
+            def _cls = new ClassLoaderHelper().searchForClass(analysis.configuration.workflowClass)
+            if (!_cls) throw new ClassNotFoundException("Class not found ${analysis.configuration.workflowClass}.")
+        } catch (ClassNotFoundException ex) {
+            throw new ProjectLoaderException("The configured workflow class ${analysis.configuration.workflowClass} for analysis ${analysisID} does not exist or could not be loaded.\n\t- Is the plugin properly compiled?\n\t- Is the workflow class spelled correctly?")
+        }
     }
 
     AnalysisConfiguration loadAnalysisConfigurationFromProjectConfigurationOrFail(ProjectConfiguration projectConfiguration, String analysisID) {

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoaderException.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoaderException.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/RuntimeService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/SuperCohortDataSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/SuperCohortDataSet.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/core/SuperCohortDataSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/SuperCohortDataSet.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/Workflow.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/BaseMetadataTable.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/BaseMetadataTable.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/BaseMetadataTable.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/BaseMetadataTable.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/ExecutionService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/FileAttributes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/FileAttributes.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/FileAttributes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/FileAttributes.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/MetadataTableFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/MetadataTableFactory.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/MetadataTableFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/MetadataTableFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/RemoteExecutionService.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/RemoteExecutionService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/RemoteExecutionService.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/RemoteExecutionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 /*

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -16,10 +16,12 @@ import com.jcraft.jsch.agentproxy.ConnectorFactory
 import com.jcraft.jsch.agentproxy.Identity
 import com.jcraft.jsch.agentproxy.sshj.AuthAgent
 import de.dkfz.roddy.Constants
+import de.dkfz.roddy.ExitReasons
 import de.dkfz.roddy.Roddy
+import de.dkfz.roddy.config.RoddyAppConfig
+import de.dkfz.roddy.execution.io.FileAttributes
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.tools.LoggerWrapper
-import de.dkfz.roddy.config.RoddyAppConfig
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods
 import de.dkfz.roddy.tools.RoddyIOHelperMethods
 import net.schmizz.sshj.SSHClient
@@ -157,6 +159,8 @@ class SSHExecutionService extends RemoteExecutionService {
                 c.startSession()
                 t2 = System.nanoTime()
                 logger.sometimes(RoddyIOHelperMethods.printTimingInfo("start ssh client session", t1, t2))
+            } catch (UnknownHostException ex) {
+                Roddy.exit(ExitReasons.unknownSSHHost)
             } catch (UserAuthException ex) {
                 logger.severe(
                         [
@@ -170,10 +174,10 @@ class SSHExecutionService extends RemoteExecutionService {
                         ].join("\n\t")
                 )
 
-                Roddy.exit(1)
+                Roddy.exit(ExitReasons.invalidSSHConfig.code)
             } catch (Exception ex) {
                 logger.severe("Fatal and unknown error during initialization of SSHExecutionService. Message: \"${ex.message}\".")
-                Roddy.exit(1)
+                Roddy.exit(ExitReasons.fatalSSHError.code)
             }
             client = c
             sftpClient = client.newSFTPClient()
@@ -219,10 +223,12 @@ class SSHExecutionService extends RemoteExecutionService {
             if (![Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_PWD, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_KEYFILE, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_SSHAGENT].contains(sshMethod))
                 sshMethod = Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_PWD
 
+
             List<SSHPoolConnectionSet> tempEntries = new LinkedList<>()
             String[] sshHosts = appConf.getOrSetApplicationProperty(Roddy.getRunMode(), Constants.APP_PROPERTY_EXECUTION_SERVICE_HOSTS).split(SPLIT_COMMA)
             int i = 0
             for (String host : sshHosts) {
+                logger.always("Opening SSH connection: $sshUser@$host via $sshMethod")
                 SSHPoolConnectionSet cs = new SSHPoolConnectionSet(i++, sshUser, host, sshMethod)
                 cs.initialize()
                 if (cs.check())
@@ -313,15 +319,6 @@ class SSHExecutionService extends RemoteExecutionService {
 
     @Override
     boolean initialize() {
-        return initialize(false)
-    }
-
-    boolean initialize(boolean waitFor) {
-        if (!waitFor) {
-            Thread.start { connectionPool.initialize() }
-            return true
-        }
-
         return connectionPool.initialize()
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
@@ -186,7 +186,7 @@ class BashCommandSet extends ShellCommandSet {
 
     @Override
     String getListFilesInDirectoryCommand(File path) {
-        return "find ${path.absolutePath} -type f -maxdepth 1"
+        return "find -L ${path.absolutePath} -type f -maxdepth 1"
     }
 
     @Override
@@ -197,7 +197,7 @@ class BashCommandSet extends ShellCommandSet {
 
     @Override
     String getListFullDirectoryContentRecursivelyCommand(File f, int depth, FileType selectedType, boolean detailed) {
-        StringBuilder sb = new StringBuilder("find ")
+        StringBuilder sb = new StringBuilder("find -L ")
         sb << "\"" << f.absolutePath << "\""
 
         if (depth > 0) sb << " -maxdepth ${depth}"

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemInfoObject.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemInfoObject.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemInfoObject.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemInfoObject.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/NoNoFileSystemAccessProvider.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/NoNoFileSystemAccessProvider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/NoNoFileSystemAccessProvider.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/NoNoFileSystemAccessProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/ShellCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/ShellCommandSet.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/ShellCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/ShellCommandSet.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/CopyFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/CopyFileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/CopyFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/CopyFileCommand.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/IOCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/IOCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/IOCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/IOCommand.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/ReadFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/ReadFileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/ReadFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/ReadFileCommand.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/StoreFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/StoreFileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/StoreFileCommand.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/commands/StoreFileCommand.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs.commands;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobConstants.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobConstants.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobConstants.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobManager.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobManager.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobManager.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/JobManager.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedFile.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedJob.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedJob.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/LoadedJob.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/ReadOutJob.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/ReadOutJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/ReadOutJob.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/ReadOutJob.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/ScriptCallingMethod.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/ScriptCallingMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/ScriptCallingMethod.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/ScriptCallingMethod.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/StaticScriptProviderClass.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/StaticScriptProviderClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/StaticScriptProviderClass.java
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/StaticScriptProviderClass.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflow.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows
 
 import de.dkfz.roddy.Roddy

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.knowledge.brawlworkflows
 

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.knowledge.brawlworkflows;
 

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflow.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows;
 
 import de.dkfz.roddy.config.ConfigurationError

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflowToolCall.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflowToolCall.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.knowledge.brawlworkflows
 

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflowToolCall.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlWorkflowToolCall.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows
 
 import de.dkfz.roddy.config.ConfigurationError

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflow.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.brawlworkflows

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/AbstractFileObjectTuple.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/AbstractFileObjectTuple.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/AbstractFileObjectTuple.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/AbstractFileObjectTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObject.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObject.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObject.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObjectTupleFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObjectTupleFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObjectTupleFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileObjectTupleFactory.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStageSettings.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStageSettings.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStageSettings.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStageSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFile.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFileGroup.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFileGroup.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/GenericFileGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/ITestdataSource.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/ITestdataSource.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/ITestdataSource.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/ITestdataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/IndexedFileObjects.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/IndexedFileObjects.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/IndexedFileObjects.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/IndexedFileObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/LoadedFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/LoadedFile.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/LoadedFile.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/LoadedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple10.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple10.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple10.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple11.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple11.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple11.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple12.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple12.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple12.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple13.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple13.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple13.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple13.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple14.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple14.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple14.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple15.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple15.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple15.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple2.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple2.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple2.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple3.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple3.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple3.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple4.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple4.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple4.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple5.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple5.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple5.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple6.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple6.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple6.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple7.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple7.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple7.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple8.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple8.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple8.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple9.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple9.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple9.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/Tuple9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.methods

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/GenericJobInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/GenericJobInfo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/GenericJobInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/GenericJobInfo.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.nativeworkflows

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.nativeworkflows

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.java
@@ -1,5 +1,5 @@
 ///*
-// * Copyright (c) 2016 eilslabs.
+// * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
 // *
 // * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
 // */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.java
@@ -1,7 +1,7 @@
 ///*
 // * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
 // *
-// * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+// * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
 // */
 //
 //package de.dkfz.roddy.knowledge.nativeworkflows;

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflowConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflowConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflowConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflowConverter.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.nativeworkflows

--- a/RoddyCore/src/de/dkfz/roddy/plugins/BuildInfoFileHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/BuildInfoFileHelper.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/BuildInfoFileHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/BuildInfoFileHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/ClassLoaderHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/ClassLoaderHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/ClassLoaderHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/ClassLoaderHelper.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/JarFulPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/JarFulPluginInfo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/JarFulPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/JarFulPluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/JarLessPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/JarLessPluginInfo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/JarLessPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/JarLessPluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/NativePluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/NativePluginInfo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/NativePluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/NativePluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginDirectoryInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginDirectoryInfo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginDirectoryInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginDirectoryInfo.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfo.java
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfo.java
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfo.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins;

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginType.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginType.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginType.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginType.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/plugins/SyntheticPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/SyntheticPluginInfo.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/plugins/SyntheticPluginInfo.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/SyntheticPluginInfo.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/src/de/dkfz/roddy/tools/CollectionHelperMethods.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/CollectionHelperMethods.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/RoddyCore/src/de/dkfz/roddy/tools/CollectionHelperMethods.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/CollectionHelperMethods.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/RuntimeTools.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/RoddyCore/src/de/dkfz/roddy/tools/ScannerWrapper.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/ScannerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/tools/ScannerWrapper.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/ScannerWrapper.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple2.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple2.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple2.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple3.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple3.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple3.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple5.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/de/dkfz/roddy/tools/Tuple5.java
+++ b/RoddyCore/src/de/dkfz/roddy/tools/Tuple5.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools;

--- a/RoddyCore/src/imgs/icons_projectlist.svg
+++ b/RoddyCore/src/imgs/icons_projectlist.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  ~ Copyright (c) 2016 eilslabs.
+  ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
   ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
   -->

--- a/RoddyCore/src/imgs/icons_projectlist.svg
+++ b/RoddyCore/src/imgs/icons_projectlist.svg
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <!-- Created with Inkscape (http://www.inkscape.org/) -->

--- a/RoddyCore/src/imgs/roddy.svg
+++ b/RoddyCore/src/imgs/roddy.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  ~ Copyright (c) 2016 eilslabs.
+  ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
   ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
   -->

--- a/RoddyCore/src/imgs/roddy.svg
+++ b/RoddyCore/src/imgs/roddy.svg
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <!-- Created with Inkscape (http://www.inkscape.org/) -->

--- a/RoddyCore/src/java/io/RoddyFile.java
+++ b/RoddyCore/src/java/io/RoddyFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/src/java/io/RoddyFile.java
+++ b/RoddyCore/src/java/io/RoddyFile.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package java.io;

--- a/RoddyCore/src/logback.xml
+++ b/RoddyCore/src/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 eilslabs.
+  ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
   ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
   -->

--- a/RoddyCore/src/logback.xml
+++ b/RoddyCore/src/logback.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration>

--- a/RoddyCore/test/resources/exampleProject/config/projectsExampleMinimal.xml
+++ b/RoddyCore/test/resources/exampleProject/config/projectsExampleMinimal.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='example' description='' imports="" usedresourcessize="s">

--- a/RoddyCore/test/resources/exampleProject/config/projectsExampleMinimal.xml
+++ b/RoddyCore/test/resources/exampleProject/config/projectsExampleMinimal.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 eilslabs.
+  ~ Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
   ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
   -->

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 eilslabs.
+  ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
   ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
   -->

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysis' description='A test analysis for local and remote roddy workflow tests.' workflowClass='de.dkfz.roddy.core.Analysis'>

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017 eilslabs.
+  ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
   ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
   -->

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysis' description='A test analysis for local and remote roddy workflow tests.' workflowClass='de.dkfz.roddy.core.Analysis'>

--- a/RoddyCore/test/src/de/dkfz/roddy/HELPERSCRIPTS/ConfigurationPreparatorTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/HELPERSCRIPTS/ConfigurationPreparatorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/HELPERSCRIPTS/ConfigurationPreparatorTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/HELPERSCRIPTS/ConfigurationPreparatorTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.HELPERSCRIPTS

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyStartupModesIntegrativeUnitTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyStartupModesIntegrativeUnitTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyStartupModesIntegrativeUnitTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyStartupModesIntegrativeUnitTests.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy
 

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
@@ -25,11 +25,8 @@ class RoddyTestSpec extends Specification {
         }
     }
 
-    static final ExecutionContext genericContext
-
     static {
         ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
         FileSystemAccessProvider.initializeProvider(true)
-        genericContext = contextResource.createSimpleContext(RoddyTestSpec)
     }
 }

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy
 
 import de.dkfz.roddy.core.ContextResource

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
@@ -9,17 +9,19 @@ import de.dkfz.roddy.core.ContextResource
 import de.dkfz.roddy.execution.io.ExecutionService
 import de.dkfz.roddy.execution.io.LocalExecutionService
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import groovy.transform.CompileStatic
 import org.junit.ClassRule
+import org.junit.Rule
 import spock.lang.Shared
 import spock.lang.Specification
 
 /**
  * Base class for Spock tests which does some basic initialization stuff.
  */
+@CompileStatic
 class RoddyTestSpec extends Specification {
 
-    @ClassRule
-    @Shared
+    @Rule
     final ContextResource contextResource = new ContextResource()
 
     static {

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
@@ -6,11 +6,11 @@
 package de.dkfz.roddy
 
 import de.dkfz.roddy.core.ContextResource
-import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.execution.io.ExecutionService
 import de.dkfz.roddy.execution.io.LocalExecutionService
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import org.junit.ClassRule
+import spock.lang.Shared
 import spock.lang.Specification
 
 /**
@@ -19,11 +19,8 @@ import spock.lang.Specification
 class RoddyTestSpec extends Specification {
 
     @ClassRule
-    static final ContextResource contextResource = new ContextResource() {
-        {
-            before()
-        }
-    }
+    @Shared
+    final ContextResource contextResource = new ContextResource()
 
     static {
         ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)

--- a/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/RoddyTestSpec.groovy
@@ -1,0 +1,30 @@
+package de.dkfz.roddy
+
+import de.dkfz.roddy.core.ContextResource
+import de.dkfz.roddy.core.ExecutionContext
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import org.junit.ClassRule
+import spock.lang.Specification
+
+/**
+ * Base class for Spock tests which does some basic initialization stuff.
+ */
+class RoddyTestSpec extends Specification {
+
+    @ClassRule
+    static final ContextResource contextResource = new ContextResource() {
+        {
+            before()
+        }
+    }
+
+    static final ExecutionContext genericContext
+
+    static {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
+        genericContext = contextResource.createSimpleContext(RoddyTestSpec)
+    }
+}

--- a/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/CommandLineCallTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.cliclient

--- a/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/RoddyCLIClientTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/RoddyCLIClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/RoddyCLIClientTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/cliclient/RoddyCLIClientTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 //package de.dkfz.roddy.client.cliclient

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnectionTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnectionTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnectionTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientConnectionTests.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientServerTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientServerTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientServerTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIClientServerTests.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.client.rmiclient;

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationFactoryTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.config
 

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationIssueSpec.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
 import spock.lang.Shared

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
@@ -1,5 +1,6 @@
 package de.dkfz.roddy.config
 
+import de.dkfz.roddy.RoddyTestSpec
 import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.core.ContextResource
 import de.dkfz.roddy.core.ExecutionContext
@@ -13,22 +14,7 @@ import spock.lang.Specification
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 
-class ConfigurationValueSpec extends Specification {
-//    def "GetEnumerationValueType"() {
-//    }
-//
-
-    @ClassRule
-    static ContextResource contextResource = new ContextResource() {
-        {
-            before()
-        }
-    }
-
-    def setupSpec() {
-        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
-        FileSystemAccessProvider.initializeProvider(true)
-    }
+class ConfigurationValueSpec extends RoddyTestSpec {
 
     @Shared
     static final EnumerationValue evString = ConfigurationValue.defaultCValueTypeEnumeration.getValue(CVALUE_TYPE_STRING)

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.config
 

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ConfigurationValueSpec.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
 import de.dkfz.roddy.RoddyTestSpec

--- a/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/FilenamePatternTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.config
 

--- a/RoddyCore/test/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config
 
 import spock.lang.Specification

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolEntryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolEntryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolEntryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolEntryTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileGroupParameterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileGroupParameterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileGroupParameterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileGroupParameterTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileParameterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileParameterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileParameterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/ToolFileParameterTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config

--- a/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/converters/BashConverterTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/test/src/de/dkfz/roddy/config/converters/YAMLConverterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/converters/YAMLConverterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/config/converters/YAMLConverterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/converters/YAMLConverterTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.config.converters

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.config.validation
 

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.config.validation
 
 import de.dkfz.roddy.config.ConfigurationConstants

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -5,6 +5,7 @@
  */
 package de.dkfz.roddy.config.validation
 
+import de.dkfz.roddy.RoddyTestSpec
 import de.dkfz.roddy.config.ConfigurationConstants
 import de.dkfz.roddy.config.ConfigurationIssue
 import de.dkfz.roddy.config.ConfigurationValue
@@ -18,7 +19,7 @@ import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_INTEGER
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_STRING
 import static de.dkfz.roddy.config.ConfigurationIssue.ConfigurationIssueTemplate.*
 
-class DefaultValidatorSpec extends Specification {
+class DefaultValidatorSpec extends RoddyTestSpec {
 
     def 'test removeEscapedEscapeCharacters'(value, expected) {
         expect:

--- a/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.core
 

--- a/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/AnalysisSpec.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.core
 
 

--- a/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionSpecification.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionSpecification.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.core
 
 import de.dkfz.roddy.config.Configuration

--- a/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionSpecification.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionSpecification.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.core
 

--- a/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.core
 

--- a/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/CohortDataRuntimeServiceExtensionTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.core
 
 import de.dkfz.roddy.RunMode

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
@@ -6,7 +6,11 @@
 
 package de.dkfz.roddy.core
 
+import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.config.Configuration
+import de.dkfz.roddy.execution.io.ExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionService
+import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.knowledge.files.BaseFile
 import groovy.transform.CompileStatic
 import org.junit.Rule
@@ -14,9 +18,14 @@ import org.junit.Test
 
 @CompileStatic
 class ContextResourceTest {
-    
+
     @Rule
     public ContextResource contextResource = new ContextResource()
+
+    static {
+        ExecutionService.initializeService(LocalExecutionService, RunMode.CLI)
+        FileSystemAccessProvider.initializeProvider(true)
+    }
 
     @Test
     void testGetTestBaseDirectory() {

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResourceTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriterTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextReaderAndWriterTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ExecutionContextTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.core

--- a/RoddyCore/test/src/de/dkfz/roddy/core/RuntimeServiceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/RuntimeServiceTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 

--- a/RoddyCore/test/src/de/dkfz/roddy/core/RuntimeServiceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/RuntimeServiceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTestInlineScript.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTestInlineScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTestInlineScript.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BEExecutionServiceTestInlineScript.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BaseMetadataTableTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BaseMetadataTableTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/BaseMetadataTableTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/BaseMetadataTableTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/MetadataTableFactoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetSpecification.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetSpecification.groovy
@@ -25,18 +25,36 @@ class BashCommandSetSpecification extends Specification {
     @Shared
     File tmpc = new File("/tmp/c")
 
+    def "test getListFilesInDirectoryCommand without filters"(File dir, expected) {
+        expect:
+        b.getListFilesInDirectoryCommand(dir) == expected
+
+        where:
+        dir  | expected
+        tmpa | 'find -L /tmp/a -type f -maxdepth 1'
+    }
+
+    def "test getListFilesInDirectoryCommand with filters"(File dir, List<String> filters, expected) {
+        expect:
+        b.getListFilesInDirectoryCommand(dir, filters) == expected
+
+        where:
+        dir  | filters             | expected
+        tmpa | ["a", "??b", "*.c"] | 'ls -lL -d /tmp/a/a /tmp/a/??b /tmp/a/*.c 2> /dev/null | grep -v "^d" | awk \'{ print $9 }\' | uniq'
+    }
+
     def testGetListFullDirectoryContentRecursivelyCommand(File directory, int depth, FileType selectedType, boolean complexList, String result) {
         expect:
         b.getListFullDirectoryContentRecursivelyCommand(directory, depth, selectedType, complexList) == result
 
         where:
         directory | depth | selectedType | complexList | result
-        tmpa      | -1    | ANY          | false       | 'find "/tmp/a"'
-        tmpa      | -1    | FILES        | false       | 'find "/tmp/a" -type f'
-        tmpa      | -1    | DIRECTORIES  | true        | 'find "/tmp/a" -type d -ls'
-        tmpa      | 0     | ANY          | false       | 'find "/tmp/a"'
-        tmpa      | 1     | FILES        | false       | 'find "/tmp/a" -maxdepth 1 -type f'
-        tmpa      | 2     | DIRECTORIES  | true        | 'find "/tmp/a" -maxdepth 2 -type d -ls'
+        tmpa      | -1    | ANY          | false       | 'find -L "/tmp/a"'
+        tmpa      | -1    | FILES        | false       | 'find -L "/tmp/a" -type f'
+        tmpa      | -1    | DIRECTORIES  | true        | 'find -L "/tmp/a" -type d -ls'
+        tmpa      | 0     | ANY          | false       | 'find -L "/tmp/a"'
+        tmpa      | 1     | FILES        | false       | 'find -L "/tmp/a" -maxdepth 1 -type f'
+        tmpa      | 2     | DIRECTORIES  | true        | 'find -L "/tmp/a" -maxdepth 2 -type d -ls'
     }
 
     def testGetListFullDirectoriesContentRecursivelyCommand(List<File> directories, List<Integer> depth, FileType selectedType, boolean complexList, String result) {
@@ -45,10 +63,10 @@ class BashCommandSetSpecification extends Specification {
 
         where:
         directories  | depth  | selectedType | complexList | result
-        [tmpa]       | [-1]   | ANY          | false       | 'find "/tmp/a"'
-        [tmpa, tmpa] | [0, 0] | ANY          | false       | 'find "/tmp/a"'
-        [tmpa, tmpb] | [1, 1] | FILES        | false       | 'find "/tmp/a" -maxdepth 1 -type f && find "/tmp/b" -maxdepth 1 -type f'
-        [tmpb, tmpc] | [2, 2] | DIRECTORIES  | true        | 'find "/tmp/b" -maxdepth 2 -type d -ls && find "/tmp/c" -maxdepth 2 -type d -ls'
+        [tmpa]       | [-1]   | ANY          | false       | 'find -L "/tmp/a"'
+        [tmpa, tmpa] | [0, 0] | ANY          | false       | 'find -L "/tmp/a"'
+        [tmpa, tmpb] | [1, 1] | FILES        | false       | 'find -L "/tmp/a" -maxdepth 1 -type f && find -L "/tmp/b" -maxdepth 1 -type f'
+        [tmpb, tmpc] | [2, 2] | DIRECTORIES  | true        | 'find -L "/tmp/b" -maxdepth 2 -type d -ls && find -L "/tmp/c" -maxdepth 2 -type d -ls'
     }
 
     def testGetFindFilesUsingWildcardsCommand(File baseFolder, String wildcards, String result) {

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.io.fs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/BEJobTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/CommandTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/CommandTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/CommandTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/CommandTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/JobTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManagerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManagerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManagerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManagerTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs.cluster.pbs

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManagerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManagerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManagerTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManagerTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.execution.jobs.cluster.sge

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflowTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflowTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.knowledge.brawlworkflows
 

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflowTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/BrawlCallingWorkflowTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.brawlworkflows
 
 import de.dkfz.roddy.Constants

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflowTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflowTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflowTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/brawlworkflows/JBrawlWorkflowTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.brawlworkflows

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/BaseFileTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.files

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
 package de.dkfz.roddy.knowledge.files
 
 import de.dkfz.roddy.core.ContextResource

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/files/FileGroupTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 package de.dkfz.roddy.knowledge.files
 

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/methods/GenericMethodTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/methods/GenericMethodTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/knowledge/methods/GenericMethodTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/knowledge/methods/GenericMethodTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.methods

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/BuildInfoFileHelperTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/BuildInfoFileHelperTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/BuildInfoFileHelperTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/BuildInfoFileHelperTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryRegexMethodTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryRegexMethodTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryRegexMethodTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryRegexMethodTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/LibrariesFactoryTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/NativePluginInfoTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/NativePluginInfoTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/NativePluginInfoTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/NativePluginInfoTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoMapTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoMapTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoMapTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoMapTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins;

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/plugins/PluginInfoTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.plugins

--- a/RoddyCore/test/src/de/dkfz/roddy/tools/CollectionHelperMethodsTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/tools/CollectionHelperMethodsTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/RoddyCore/test/src/de/dkfz/roddy/tools/CollectionHelperMethodsTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/tools/CollectionHelperMethodsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 eilslabs.
+ * Copyright (c) 2017 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/tools/RuntimeToolsTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/tools/RuntimeToolsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */

--- a/RoddyCore/test/src/de/dkfz/roddy/tools/RuntimeToolsTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/tools/RuntimeToolsTest.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ configurations.all {
 dependencies {
     compile 'com.github.theroddywms:RoddyToolLib:2.0.0'         // MIT
     // compile 'com.github.theroddywms:RoddyToolLib:master-SNAPSHOT'    // MIT
-    compile 'com.github.theroddywms:BatchEuphoria:0.0.5'        // MIT
+    compile 'com.github.theroddywms:BatchEuphoria:0.0.6'        // MIT
     // compile 'com.github.theroddywms:BatchEuphoria:master-SNAPSHOT'   // MIT
     compile 'org.codehaus.groovy:groovy-all:2.4.9'              // Apache 2.0
 

--- a/dist/bin/develop/helperScripts/IncreaseAndSetBuildVersion.groovy
+++ b/dist/bin/develop/helperScripts/IncreaseAndSetBuildVersion.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 // Update build version and date in Constants.java

--- a/dist/bin/develop/helperScripts/addChangelistVersionTag.groovy
+++ b/dist/bin/develop/helperScripts/addChangelistVersionTag.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 /**

--- a/dist/bin/develop/helperScripts/convertCommandLineConfigToXML.groovy
+++ b/dist/bin/develop/helperScripts/convertCommandLineConfigToXML.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 /**

--- a/dist/bin/develop/helperScripts/findPluginFolders.groovy
+++ b/dist/bin/develop/helperScripts/findPluginFolders.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 // This script is used to extract find all plugin base folders.

--- a/dist/bin/develop/helperScripts/findPluginLibraries.groovy
+++ b/dist/bin/develop/helperScripts/findPluginLibraries.groovy
@@ -3,7 +3,7 @@ import java.nio.file.AccessDeniedException
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 

--- a/dist/bin/develop/helperScripts/prepareProjectConfiguration.groovy
+++ b/dist/bin/develop/helperScripts/prepareProjectConfiguration.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 import de.dkfz.roddy.client.RoddyStartupOptions

--- a/dist/bin/develop/helperScripts/skeletonProject_extended.xml
+++ b/dist/bin/develop/helperScripts/skeletonProject_extended.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project'

--- a/dist/bin/develop/helperScripts/skeletonProject_minimal.xml
+++ b/dist/bin/develop/helperScripts/skeletonProject_minimal.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project'

--- a/dist/bin/develop/testFiles/projectsTest.xml
+++ b/dist/bin/develop/testFiles/projectsTest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='TestProjectForUnitTests' description='Like the name says' runtimeServiceClass='de.dkfz.roddy.knowledge.examples.SimpleRuntimeService' imports="testProjectImportLvl0">

--- a/dist/bin/develop/testFiles/projectsTestImportLvl0.xml
+++ b/dist/bin/develop/testFiles/projectsTestImportLvl0.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='testProjectImportLvl0' description='Test project' runtimeServiceClass='de.dkfz.roddy.knowledge.examples.SimpleRuntimeService' imports="testProjectImportLvl1">

--- a/dist/bin/develop/testFiles/projectsTestImportLvl1.xml
+++ b/dist/bin/develop/testFiles/projectsTestImportLvl1.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='project' name='testProjectImportLvl1' description='Test project' runtimeServiceClass='de.dkfz.roddy.knowledge.examples.SimpleRuntimeService' imports="">

--- a/dist/plugins/Template/resources/configurationFiles/analysisTemplate.xml
+++ b/dist/plugins/Template/resources/configurationFiles/analysisTemplate.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='templateAnalysis' description='A template xml for java workflows.'

--- a/dist/plugins/Template/resources/configurationFiles/analysisTemplateBrawl.xml
+++ b/dist/plugins/Template/resources/configurationFiles/analysisTemplateBrawl.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='templateNativeAnalysis' description='A template for brawl workflows.'

--- a/dist/plugins/Template/resources/configurationFiles/analysisTemplateNative.xml
+++ b/dist/plugins/Template/resources/configurationFiles/analysisTemplateNative.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='templateNativeAnalysis' description='A template for native workflows.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyCValues.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyCValues.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysisFaultyCValues' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyTools.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisFaultyTools.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysisFaultyTools' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTest.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysis' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCohortWorkflow.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCohortWorkflow.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2018 DKFZ - ODCF
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='simpleCohortWorkflowAnalysis'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCorrectExecution.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCorrectExecution.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testCorrectExecutionAnalysis' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestFaultyPatterns.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestFaultyPatterns.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2017 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration name='testAnalysisFaultyPatterns' description='A test analysis for local and remote roddy workflow tests.'

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/FileWithChildren.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/FileWithChildren.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleCohortWorkflow.groovy
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleCohortWorkflow.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStage.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStage.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStageSettings.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStageSettings.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleRuntimeService.groovy
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleRuntimeService.groovy
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleTestTextFile.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleTestTextFile.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflow.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflow.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflowWithCorrectExecution.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleWorkflowWithCorrectExecution.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestPlugin.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestPlugin.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestWorkflow.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/TestWorkflow.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 eilslabs.
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
  */
 
 package de.dkfz.roddy.knowledge.examples;

--- a/dist/plugins/TestPluginWithoutJarFile/resources/configurationFiles/analysisTestNative.xml
+++ b/dist/plugins/TestPluginWithoutJarFile/resources/configurationFiles/analysisTestNative.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2016 eilslabs.
   ~
-  ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+  ~ Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
   -->
 
 <configuration configurationType='analysis'

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,3 +6,35 @@ Indicated packet length ... too large
 
 The SSH library we currently use (sshj) does not work if during your login on the submission host (on which the e.g. qsub command is executed). Make
 sure during the login no output is generated, e.g. from your `$HOME/.profile`, `$HOME/.bashrc`, etc. files.
+
+When something wents wrong and Roddy returns an error code
+----------------------------------------------------------
+
+Roddy can exit with a range of exit codes which are:
+
+.. csv-table:: "Title"
+    :Header: "Exit code", "Description"
+    :Widths: 5, 20
+
+    "255", "You must call roddy from the right location! This is the folder where roddy.sh resides."
+    "254", "SystemExitException throw by GroovyServ. Only occurs when GroovyServ is enabled (not by default!)."
+    "253", "Command line was malformed, check your input and correct mistakes."
+    "252", "Execution requirements unfulfilled. Seems you are missing some applications, please install them or ask your administrator to do it for you."
+    "251", "Startup options could not be parsed. Check your command line."
+    "250", "Cannot find requested feature toggle file. Please make sure, that the required file exists."
+    "249", "Feature toggle is not known. There are only some available. If you are unsure about this, don't use them, if not necessary."
+    "248", "Unknown problem with proxy setup. Check your proxy settings."
+    "247", "scratchBaseDir is not defined in your application ini file. Please set it so that it matches your cluster settings."
+    "246", "The wrong job manager class is set in your application ini file. Please correct that."
+    "245", "Application properties file not found or loadable. Make sure, that the file exists."
+    "244", "Could not load the requested analysis. Look for typos or take another one."
+    "243", "Severe configuration errors occurred. Take a detailed look into the error messages and your configuration file,"
+    "242", "Unhandled exception. That is a bad one. Take a look at any error message and get in contact with us."
+    "241", "Unknown SSH host. Change the hostname, it is possibly wrong."
+    "240", "SSH setup is not valid. Please follow the instructions and check your application ini file."
+    "239", "Fatal error during SSH setup. Please contact us in this case."
+    
+    "100", "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255]."
+
+In any case, we try to provide you a good explanation about what happened wrong and how you can solve it. If you find
+the messages hard to understand, contact us.


### PR DESCRIPTION
Add the RoddyTestSpec class, update Copyright notices

Updated the copyright notice in all files to our current version.

This class RoddyTestSpec extends the Groovy Specification class and 
is used to do some basic initialization like the FileSystemProvier and 
the ExecutionService.