### PR TITLE
Fix behaviour of syscalls to find in BashCommandSet

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
@@ -186,7 +186,7 @@ class BashCommandSet extends ShellCommandSet {
 
     @Override
     String getListFilesInDirectoryCommand(File path) {
-        return "find ${path.absolutePath} -type f -maxdepth 1"
+        return "find -L ${path.absolutePath} -type f -maxdepth 1"
     }
 
     @Override
@@ -200,7 +200,7 @@ class BashCommandSet extends ShellCommandSet {
         StringBuilder sb = new StringBuilder("find ")
         sb << "\"" << f.absolutePath << "\""
 
-        if (depth > 0) sb << " -maxdepth ${depth}"
+        if (depth > 0) sb << " -L -maxdepth ${depth}"
         if (selectedType == FileType.DIRECTORIES) sb << " -type d"
         if (selectedType == FileType.FILES) sb << " -type f"
         if (detailed) sb << " -ls"

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/BashCommandSet.groovy
@@ -197,10 +197,10 @@ class BashCommandSet extends ShellCommandSet {
 
     @Override
     String getListFullDirectoryContentRecursivelyCommand(File f, int depth, FileType selectedType, boolean detailed) {
-        StringBuilder sb = new StringBuilder("find ")
+        StringBuilder sb = new StringBuilder("find -L ")
         sb << "\"" << f.absolutePath << "\""
 
-        if (depth > 0) sb << " -L -maxdepth ${depth}"
+        if (depth > 0) sb << " -maxdepth ${depth}"
         if (selectedType == FileType.DIRECTORIES) sb << " -type d"
         if (selectedType == FileType.FILES) sb << " -type f"
         if (detailed) sb << " -ls"

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetSpecification.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/fs/BashCommandSetSpecification.groovy
@@ -25,18 +25,36 @@ class BashCommandSetSpecification extends Specification {
     @Shared
     File tmpc = new File("/tmp/c")
 
+    def "test getListFilesInDirectoryCommand without filters"(File dir, expected) {
+        expect:
+        b.getListFilesInDirectoryCommand(dir) == expected
+
+        where:
+        dir  | expected
+        tmpa | 'find -L /tmp/a -type f -maxdepth 1'
+    }
+
+    def "test getListFilesInDirectoryCommand with filters"(File dir, List<String> filters, expected) {
+        expect:
+        b.getListFilesInDirectoryCommand(dir, filters) == expected
+
+        where:
+        dir  | filters             | expected
+        tmpa | ["a", "??b", "*.c"] | 'ls -lL -d /tmp/a/a /tmp/a/??b /tmp/a/*.c 2> /dev/null | grep -v "^d" | awk \'{ print $9 }\' | uniq'
+    }
+
     def testGetListFullDirectoryContentRecursivelyCommand(File directory, int depth, FileType selectedType, boolean complexList, String result) {
         expect:
         b.getListFullDirectoryContentRecursivelyCommand(directory, depth, selectedType, complexList) == result
 
         where:
         directory | depth | selectedType | complexList | result
-        tmpa      | -1    | ANY          | false       | 'find "/tmp/a"'
-        tmpa      | -1    | FILES        | false       | 'find "/tmp/a" -type f'
-        tmpa      | -1    | DIRECTORIES  | true        | 'find "/tmp/a" -type d -ls'
-        tmpa      | 0     | ANY          | false       | 'find "/tmp/a"'
-        tmpa      | 1     | FILES        | false       | 'find "/tmp/a" -maxdepth 1 -type f'
-        tmpa      | 2     | DIRECTORIES  | true        | 'find "/tmp/a" -maxdepth 2 -type d -ls'
+        tmpa      | -1    | ANY          | false       | 'find -L "/tmp/a"'
+        tmpa      | -1    | FILES        | false       | 'find -L "/tmp/a" -type f'
+        tmpa      | -1    | DIRECTORIES  | true        | 'find -L "/tmp/a" -type d -ls'
+        tmpa      | 0     | ANY          | false       | 'find -L "/tmp/a"'
+        tmpa      | 1     | FILES        | false       | 'find -L "/tmp/a" -maxdepth 1 -type f'
+        tmpa      | 2     | DIRECTORIES  | true        | 'find -L "/tmp/a" -maxdepth 2 -type d -ls'
     }
 
     def testGetListFullDirectoriesContentRecursivelyCommand(List<File> directories, List<Integer> depth, FileType selectedType, boolean complexList, String result) {
@@ -45,10 +63,10 @@ class BashCommandSetSpecification extends Specification {
 
         where:
         directories  | depth  | selectedType | complexList | result
-        [tmpa]       | [-1]   | ANY          | false       | 'find "/tmp/a"'
-        [tmpa, tmpa] | [0, 0] | ANY          | false       | 'find "/tmp/a"'
-        [tmpa, tmpb] | [1, 1] | FILES        | false       | 'find "/tmp/a" -maxdepth 1 -type f && find "/tmp/b" -maxdepth 1 -type f'
-        [tmpb, tmpc] | [2, 2] | DIRECTORIES  | true        | 'find "/tmp/b" -maxdepth 2 -type d -ls && find "/tmp/c" -maxdepth 2 -type d -ls'
+        [tmpa]       | [-1]   | ANY          | false       | 'find -L "/tmp/a"'
+        [tmpa, tmpa] | [0, 0] | ANY          | false       | 'find -L "/tmp/a"'
+        [tmpa, tmpb] | [1, 1] | FILES        | false       | 'find -L "/tmp/a" -maxdepth 1 -type f && find -L "/tmp/b" -maxdepth 1 -type f'
+        [tmpb, tmpc] | [2, 2] | DIRECTORIES  | true        | 'find -L "/tmp/b" -maxdepth 2 -type d -ls && find -L "/tmp/c" -maxdepth 2 -type d -ls'
     }
 
     def testGetFindFilesUsingWildcardsCommand(File baseFolder, String wildcards, String result) {


### PR DESCRIPTION
Change getListFilesInDirectoryCommand to use -L in the find method. This
will allow Roddy to follow symbolic (file) links. Directory links will
still be omitted.

Also apply this change to getListFullDirectoryContentRecursivelyCommand.
Change tests to match the new call to find.

Add tests for getListFilesInDirectoryCommand()