### PR TITLE
Add a check for missing workflow classes

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -17,6 +17,7 @@ import de.dkfz.roddy.config.loader.ConfigurationLoaderException
 import de.dkfz.roddy.config.validation.XSDValidator
 import de.dkfz.roddy.execution.io.MetadataTableFactory
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
+import de.dkfz.roddy.plugins.ClassLoaderHelper
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.plugins.PluginInfo
 import de.dkfz.roddy.plugins.PluginInfoMap
@@ -387,6 +388,12 @@ class ProjectLoader {
 
         if (analysis == null)
             throw new ProjectLoaderException("Could not load analysis ${analysisID}")
+
+        try {
+            new ClassLoaderHelper().searchForClass(analysis.configuration.workflowClass)
+        } catch (ClassNotFoundException ex) {
+            throw new ProjectLoaderException("The configured workflow class ${analysis.configuration.workflowClass} for analysis ${analysisID} does not exist or could not be loaded.\n\t- Is the plugin properly compiled?\n\t- Is the workflow class spelled correctly?")
+        }
     }
 
     AnalysisConfiguration loadAnalysisConfigurationFromProjectConfigurationOrFail(ProjectConfiguration projectConfiguration, String analysisID) {

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -390,7 +390,8 @@ class ProjectLoader {
             throw new ProjectLoaderException("Could not load analysis ${analysisID}")
 
         try {
-            new ClassLoaderHelper().searchForClass(analysis.configuration.workflowClass)
+            def _cls = new ClassLoaderHelper().searchForClass(analysis.configuration.workflowClass)
+            if (!_cls) throw new ClassNotFoundException("Class not found ${analysis.configuration.workflowClass}.")
         } catch (ClassNotFoundException ex) {
             throw new ProjectLoaderException("The configured workflow class ${analysis.configuration.workflowClass} for analysis ${analysisID} does not exist or could not be loaded.\n\t- Is the plugin properly compiled?\n\t- Is the workflow class spelled correctly?")
         }


### PR DESCRIPTION
Add a check, if the workflow class of a loaded analysis exists. If the
class is not available, print an error message and abort.