### PR TITLE
Reenabled ForbidSubmissionOnRunning and made it default

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
@@ -40,7 +40,7 @@ enum AvailableFeatureToggles {
     ////////////////////////
     */
     @Deprecated
-    ForbidSubmissionOnRunning(false),
+    ForbidSubmissionOnRunning(true),
 
     @Deprecated
     BreakSubmissionOnError(false),

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
@@ -251,9 +251,6 @@ public class Analysis {
     }
 
     private boolean canStartJobs(DataSet ds) {
-        if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning)) {
-            throw new RuntimeException("Feature toggle forbidSubmissionOnRunning is currently unsupported due to lack of use by users. If you need it contact the developers.");
-        }
         return !Roddy.getFeatureToggleValue(AvailableFeatureToggles.ForbidSubmissionOnRunning) || !hasKnownRunningJobs(ds);
     }
 


### PR DESCRIPTION
ForbidSubmissionOnRunning was supposed to be disfunctional. However, I
could see in some tests, that it still runs and also recognizes, if the
running jobs belong to a different analysis.

Made the option enabled by default, because it makes Roddy more strict.