### PR TITLE
Several bugfixes related to JobManager issues.

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/Constants.java
+++ b/RoddyCore/src/de/dkfz/roddy/Constants.java
@@ -41,6 +41,7 @@ public class Constants {
     public static final String APP_PROPERTY_SCRATCH_BASE_DIRECTORY = "scratchBaseDirectory";
     public static final String APP_PROPERTY_JOB_MANAGER_PASS_ENVIRONMENT = "jobManagerPassEnvironment";
     public static final String APP_PROPERTY_JOB_MANAGER_HOLDJOBS_ON_SUBMISSION = "jobManagerHoldJobsOnSubmission";
+    public static final String APP_PROPERTY_JOB_MANAGER_UPDATE_INTERVAL = "jobManagerUpdateInterval";
     public static final String APP_PROPERTY_BASE_ENVIRONMENT_SCRIPT = "baseEnvironmentScript";
 
     /////////////////////////

--- a/RoddyCore/src/de/dkfz/roddy/Constants.java
+++ b/RoddyCore/src/de/dkfz/roddy/Constants.java
@@ -52,8 +52,6 @@ public class Constants {
     public static final String ERR_MSG_WRONG_PARAMETER_COUNT = "You did not provide proper parameters, args.length = ";
     public static final String ERR_MSG_NO_APPLICATION_PROPERTY_FILE = "Configuration does not exist. Cannot start application.";
 
-//    public static final String APP_EXITCODE_
-
     /////////////////////////
     // Environment settings
     /////////////////////////

--- a/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
@@ -25,9 +25,11 @@ enum ExitReasons {
     analysisNotLoadable(244, "Could not load analysis"),
     severeConfigurationErrors(243, "Severe configuration errors occurred."),
     unhandledException(242, "Unhandled exception."),
-    unknownSSHHost(241, "Unknown SSH host."),
+    unknownSSHHost(241, "Could not setup SSH access with your configuration: The specified host is not available ."),
     invalidSSHConfig(240, "SSH setup is not valid."),
     fatalSSHError(239, "Fatal error during SSH setup."),
+    aJobHadAnError(238, "At least one of your started jobs exited with an error."),
+    waitForJobsFailedWithAnUnknownError(237, "Roddy.waitForJobs() failed with an unknown exception."),
 
     wrongExitCodeUsed(100, "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255].")
 

--- a/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/Roddy/LICENSE.txt).
+ */
+
+package de.dkfz.roddy
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+enum ExitReasons {
+
+    wrongStartupLocation(255, "You must call roddy from the right location! (Base roddy folder where roddy.sh resides."),
+    groovyServError(254, "SystemExitException throw by GroovyServ, will exit now."),
+    malformedCommandLine(253, "Command line was malformed."),
+    unfulfilledRequirements(252, "Execution requirements unfulfilled."),
+    unparseableStartupOptions(251, "Startup options could not be parsed."),
+    unknownFeatureToggleFile(250, "Cannot find requested feature toggle file."),
+    unknownFeatureToggle(249, "Feature toggle is not known."),
+    unknownProxyProblem(248, "Unknown problem with proxy setup."),
+    scratchDirNotConfigured(247, Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY + " is not defined."),
+    wrongJobManagerClass(246, "Wrong job manager class."),
+    appPropertiesFileNotFound(245, "Application properties file not found or loadable."),
+    analysisNotLoadable(244, "Could not load analysis"),
+    severeConfigurationErrors(243, "Severe configuration errors occurred."),
+    unhandledException(242, "Unhandled exception."),
+    unknownSSHHost(241, "Unknown SSH host."),
+    invalidSSHConfig(240, "SSH setup is not valid."),
+    fatalSSHError(239, "Fatal error during SSH setup."),
+
+    wrongExitCodeUsed(100, "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255].")
+
+    final String message
+
+    final int code
+
+    ExitReasons(int code, String message) {
+        this.message = message
+        this.code = code
+    }
+}

--- a/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/ExitReasons.groovy
@@ -25,10 +25,10 @@ enum ExitReasons {
     analysisNotLoadable(244, "Could not load analysis"),
     severeConfigurationErrors(243, "Severe configuration errors occurred."),
     unhandledException(242, "Unhandled exception."),
-    unknownSSHHost(241, "Could not setup SSH access with your configuration: The specified host is not available ."),
+    unknownSSHHost(241, "SSH remote host could not be reached."),
     invalidSSHConfig(240, "SSH setup is not valid."),
     fatalSSHError(239, "Fatal error during SSH setup."),
-    aJobHadAnError(238, "At least one of your started jobs exited with an error."),
+    aJobHadAnError(238, "At least one job exited with an error."),
     waitForJobsFailedWithAnUnknownError(237, "Roddy.waitForJobs() failed with an unknown exception."),
 
     wrongExitCodeUsed(100, "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255].")

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -772,7 +772,7 @@ public class Roddy {
     private static int waitForJobs() {
         try {
             if (jobManager.isDaemonAlive()) {
-                logger.always("Roddy will wait now, until all started jobs are finished.");
+                logger.always("Waiting now, until all jobs are finished.");
                 Thread.sleep(5000); //Sleep at least 5 seconds to let any job scheduler handle things...
                 if (jobManager.waitForJobsToFinish()) {
                     return ExitReasons.aJobHadAnError.getCode();

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -205,7 +205,7 @@ public class Roddy {
             if (list == null || list.length != 1) {
                 System.out.println("You must call roddy from the right location! (Base roddy folder where roddy.sh resides). You used: '" +
                         applicationDirectory + "'");
-                System.exit(255);
+                System.exit(ExitReasons.wrongStartupLocation.getCode());
             }
 
             if (args.length == 0) {
@@ -226,7 +226,7 @@ public class Roddy {
             // we check for this particular exception by using its simple class name!
             if (!e.getClass().getName().endsWith("SystemExitException"))
                 e.printStackTrace();
-            exit(1);
+            exit(ExitReasons.groovyServError.getCode());
         }
     }
 
@@ -252,7 +252,7 @@ public class Roddy {
         CommandLineCall clc = new CommandLineCall(list);
         commandLineCall = clc;
         if (clc.isMalformed())
-            exit(1);
+            exit(ExitReasons.malformedCommandLine.getCode());
 
         // Initialize the logger with an initial setup. At this point we don't know about things like the logger settings
         // or the used app ini file. However, all the following methods rely on an existing valid logger setup.
@@ -262,7 +262,7 @@ public class Roddy {
 
         time("initial checks");
         if (!roddyExecutionRequirementsFulfilled())
-            exit(1);
+            exit(ExitReasons.unfulfilledRequirements.getCode());
 
         time("ftoggleini");
         initializeFeatureToggles();
@@ -285,7 +285,7 @@ public class Roddy {
         }
 
         if (!jobExecutionRequirementsFulfilled())
-            exit(1);
+            exit(ExitReasons.unfulfilledRequirements.getCode());
 
         time("initserv");
         parseRoddyStartupModeAndRun(clc);
@@ -430,7 +430,7 @@ public class Roddy {
             }
         } catch (RuntimeException e) {
             logger.severe("Parsing startup options failed.");
-            exit(1);
+            exit(ExitReasons.unparseableStartupOptions.getCode());
         }
     }
 
@@ -441,7 +441,7 @@ public class Roddy {
             logger.postSometimesInfo("Trying to load alternative feature toggles file: " + toggleIni);
             if (toggleIni == null || !toggleIni.exists()) {
                 logger.postAlwaysInfo("Cannot find requested toggle file.");
-                exit(1);
+                exit(ExitReasons.unknownFeatureToggleFile.getCode());
             }
 
         } else {
@@ -469,7 +469,7 @@ public class Roddy {
             String toggleNames = RoddyIOHelperMethods.joinArray(AvailableFeatureToggles.values(), "\n\t");
             logger.severe("Available toggle values are:\n\t" + toggleNames);
             if (isStrictModeEnabled())
-                exit(1);
+                exit(ExitReasons.unknownFeatureToggle.getCode());
         }
     }
 
@@ -575,7 +575,7 @@ public class Roddy {
                 l = ProxySelector.getDefault().select(new URI("http://codemirror.net"));
             } catch (URISyntaxException e) {
                 e.printStackTrace();
-                System.exit(1);
+                System.exit(ExitReasons.unknownProxyProblem.getCode());
             }
 
             if (l != null) {
@@ -637,7 +637,7 @@ public class Roddy {
                 propertyFilePath = Roddy.getPropertiesFilePath();
                 System.err.println(Constants.APP_PROPERTY_SCRATCH_BASE_DIRECTORY +
                         " is not defined. Please add it to your application properties file: '" + propertyFilePath + "'");
-                System.exit(1);
+                System.exit(ExitReasons.scratchDirNotConfigured.getCode());
             } catch (FileNotFoundException e) {
                 // The file must have existed, because we are accessing the values in it.
                 scratchBaseDir = System.getenv("CURRENT_PWD");
@@ -714,7 +714,7 @@ public class Roddy {
                 available.append("\n\t" + acs.getClassName());
             }
             logger.severe("Could not find job manager class: " + jobManagerClassID + ", available are: " + available.toString() + "\nPlease set the jobManagerClass entry in your application ini file: " + getPropertiesFilePath().getAbsolutePath() + "");
-            exit(1);
+            exit(ExitReasons.wrongJobManagerClass.getCode());
         }
 
         /** Get the constructor which comes with no parameters */
@@ -786,7 +786,7 @@ public class Roddy {
         Initializable.destroyAll();
         if (jobManager != null)
             jobManager.stopUpdateDaemon();
-        System.exit(ecode <= 250 ? ecode : 250); //Exit codes should be in range from 0 .. 255
+        System.exit(ecode <= 255 ? ecode : ExitReasons.wrongExitCodeUsed.getCode()); //Exit codes should be in range from 0 .. 255
     }
 
     public static void loadPropertiesFile() {
@@ -795,7 +795,7 @@ public class Roddy {
             file = getPropertiesFilePath();
         } catch (FileNotFoundException e) {
             logger.postAlwaysInfo("Could not load the application properties file: " + e.getMessage() + ". Roddy will exit.");
-            exit(1);
+            exit(ExitReasons.appPropertiesFileNotFound.getCode());
         }
         logger.postAlwaysInfo("Loading properties file " + file.getAbsolutePath() + ".");
 

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -69,7 +69,7 @@ class RoddyCLIClient {
 
     static void startMode(CommandLineCall clc) {
         //TODO Convert to CommandLineCall
-        String[] args = clc.getArguments();
+        String[] args = clc.getArguments().toArray(new String[0]);
         switch (clc.startupMode) {
             case showreadme:
                 showReadme();
@@ -276,7 +276,7 @@ class RoddyCLIClient {
         Analysis analysis = new ProjectLoader().loadAnalysisAndProject(analysisID)
         if (!analysis) {
             logger.severe("Could not load analysis ${analysisID}")
-            Roddy.exit(1)
+            Roddy.exit(ExitReasons.analysisNotLoadable.getCode())
         }
         // This check only applies for analysis configuration files.
         checkConfigurationErrorsAndMaybePrintAndFail(analysis.configuration)
@@ -294,7 +294,7 @@ class RoddyCLIClient {
             } else {
                 logger.severe("There were configuration errors and Roddy will not start. Consider using --${RoddyStartupOptions.ignoreconfigurationerrors.name()} to ignore errors.")
                 System.err.println(errorText)
-                Roddy.exit(1)
+                Roddy.exit(ExitReasons.severeConfigurationErrors.code)
             }
         }
     }

--- a/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/netsubmission/RoddyNetworkSubmissionServer.groovy
@@ -41,7 +41,7 @@ public class RoddyNetworkSubmissionServer {
 
         } catch (Exception ex) {
             System.out.println(ex);
-            System.exit(1);
+            System.exit(ExitReasons.unhandledException.code);
         }
 
         //Just exit without an error

--- a/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RoddyAppConfig.java
@@ -57,6 +57,12 @@ public class RoddyAppConfig extends AppConfig {
             case "string":
                 value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
                 break;
+            case "integer":
+                if (!RoddyConversionHelperMethods.isInteger(defaultValue)) {
+                    throw new ConfigurationError(String.format("The value for '%s' is not of type '%s'", pName, type), pName);
+                }
+                value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
+                break;
             case "path":
                 value = uncheckedGetOrSetApplicationProperty(pName, defaultValue);
                 break;

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -17,9 +17,10 @@ import com.jcraft.jsch.agentproxy.Identity
 import com.jcraft.jsch.agentproxy.sshj.AuthAgent
 import de.dkfz.roddy.Constants
 import de.dkfz.roddy.Roddy
+import de.dkfz.roddy.config.RoddyAppConfig
+import de.dkfz.roddy.execution.io.FileAttributes
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.tools.LoggerWrapper
-import de.dkfz.roddy.config.RoddyAppConfig
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods
 import de.dkfz.roddy.tools.RoddyIOHelperMethods
 import net.schmizz.sshj.SSHClient
@@ -157,6 +158,9 @@ class SSHExecutionService extends RemoteExecutionService {
                 c.startSession()
                 t2 = System.nanoTime()
                 logger.sometimes(RoddyIOHelperMethods.printTimingInfo("start ssh client session", t1, t2))
+            } catch (UnknownHostException ex) {
+                logger.severe("Could not setup SSH access with your configuration: The specified host is not available - ${ex.message}")
+                Roddy.exit(255)
             } catch (UserAuthException ex) {
                 logger.severe(
                         [
@@ -170,10 +174,10 @@ class SSHExecutionService extends RemoteExecutionService {
                         ].join("\n\t")
                 )
 
-                Roddy.exit(1)
+                Roddy.exit(255)
             } catch (Exception ex) {
                 logger.severe("Fatal and unknown error during initialization of SSHExecutionService. Message: \"${ex.message}\".")
-                Roddy.exit(1)
+                Roddy.exit(255)
             }
             client = c
             sftpClient = client.newSFTPClient()
@@ -219,10 +223,12 @@ class SSHExecutionService extends RemoteExecutionService {
             if (![Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_PWD, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_KEYFILE, Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_SSHAGENT].contains(sshMethod))
                 sshMethod = Constants.APP_PROPERTY_EXECUTION_SERVICE_AUTH_METHOD_PWD
 
+
             List<SSHPoolConnectionSet> tempEntries = new LinkedList<>()
             String[] sshHosts = appConf.getOrSetApplicationProperty(Roddy.getRunMode(), Constants.APP_PROPERTY_EXECUTION_SERVICE_HOSTS).split(SPLIT_COMMA)
             int i = 0
             for (String host : sshHosts) {
+                logger.always("Opening SSH connection: $sshUser@$host via $sshMethod")
                 SSHPoolConnectionSet cs = new SSHPoolConnectionSet(i++, sshUser, host, sshMethod)
                 cs.initialize()
                 if (cs.check())
@@ -313,15 +319,6 @@ class SSHExecutionService extends RemoteExecutionService {
 
     @Override
     boolean initialize() {
-        return initialize(false)
-    }
-
-    boolean initialize(boolean waitFor) {
-        if (!waitFor) {
-            Thread.start { connectionPool.initialize() }
-            return true
-        }
-
         return connectionPool.initialize()
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -160,8 +160,7 @@ class SSHExecutionService extends RemoteExecutionService {
                 t2 = System.nanoTime()
                 logger.sometimes(RoddyIOHelperMethods.printTimingInfo("start ssh client session", t1, t2))
             } catch (UnknownHostException ex) {
-                logger.severe("Could not setup SSH access with your configuration: The specified host is not available - ${ex.message}")
-                Roddy.exit(ExitReasons.unknownSSHHost.code)
+                Roddy.exit(ExitReasons.unknownSSHHost)
             } catch (UserAuthException ex) {
                 logger.severe(
                         [

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -16,6 +16,7 @@ import com.jcraft.jsch.agentproxy.ConnectorFactory
 import com.jcraft.jsch.agentproxy.Identity
 import com.jcraft.jsch.agentproxy.sshj.AuthAgent
 import de.dkfz.roddy.Constants
+import de.dkfz.roddy.ExitReasons
 import de.dkfz.roddy.Roddy
 import de.dkfz.roddy.config.RoddyAppConfig
 import de.dkfz.roddy.execution.io.FileAttributes
@@ -160,7 +161,7 @@ class SSHExecutionService extends RemoteExecutionService {
                 logger.sometimes(RoddyIOHelperMethods.printTimingInfo("start ssh client session", t1, t2))
             } catch (UnknownHostException ex) {
                 logger.severe("Could not setup SSH access with your configuration: The specified host is not available - ${ex.message}")
-                Roddy.exit(255)
+                Roddy.exit(ExitReasons.unknownSSHHost.code)
             } catch (UserAuthException ex) {
                 logger.severe(
                         [
@@ -174,10 +175,10 @@ class SSHExecutionService extends RemoteExecutionService {
                         ].join("\n\t")
                 )
 
-                Roddy.exit(255)
+                Roddy.exit(ExitReasons.invalidSSHConfig.code)
             } catch (Exception ex) {
                 logger.severe("Fatal and unknown error during initialization of SSHExecutionService. Message: \"${ex.message}\".")
-                Roddy.exit(255)
+                Roddy.exit(ExitReasons.fatalSSHError.code)
             }
             client = c
             sftpClient = client.newSFTPClient()

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ configurations.all {
 dependencies {
     compile 'com.github.theroddywms:RoddyToolLib:2.0.0'         // MIT
     // compile 'com.github.theroddywms:RoddyToolLib:master-SNAPSHOT'    // MIT
-    compile 'com.github.theroddywms:BatchEuphoria:0.0.5'        // MIT
+    compile 'com.github.theroddywms:BatchEuphoria:0.0.6'        // MIT
     // compile 'com.github.theroddywms:BatchEuphoria:master-SNAPSHOT'   // MIT
     compile 'org.codehaus.groovy:groovy-all:2.4.9'              // Apache 2.0
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,3 +6,35 @@ Indicated packet length ... too large
 
 The SSH library we currently use (sshj) does not work if during your login on the submission host (on which the e.g. qsub command is executed). Make
 sure during the login no output is generated, e.g. from your `$HOME/.profile`, `$HOME/.bashrc`, etc. files.
+
+When something wents wrong and Roddy returns an error code
+----------------------------------------------------------
+
+Roddy can exit with a range of exit codes which are:
+
+.. csv-table:: "Title"
+    :Header: "Exit code", "Description"
+    :Widths: 5, 20
+
+    "255", "You must call roddy from the right location! This is the folder where roddy.sh resides."
+    "254", "SystemExitException throw by GroovyServ. Only occurs when GroovyServ is enabled (not by default!)."
+    "253", "Command line was malformed, check your input and correct mistakes."
+    "252", "Execution requirements unfulfilled. Seems you are missing some applications, please install them or ask your administrator to do it for you."
+    "251", "Startup options could not be parsed. Check your command line."
+    "250", "Cannot find requested feature toggle file. Please make sure, that the required file exists."
+    "249", "Feature toggle is not known. There are only some available. If you are unsure about this, don't use them, if not necessary."
+    "248", "Unknown problem with proxy setup. Check your proxy settings."
+    "247", "scratchBaseDir is not defined in your application ini file. Please set it so that it matches your cluster settings."
+    "246", "The wrong job manager class is set in your application ini file. Please correct that."
+    "245", "Application properties file not found or loadable. Make sure, that the file exists."
+    "244", "Could not load the requested analysis. Look for typos or take another one."
+    "243", "Severe configuration errors occurred. Take a detailed look into the error messages and your configuration file,"
+    "242", "Unhandled exception. That is a bad one. Take a look at any error message and get in contact with us."
+    "241", "Unknown SSH host. Change the hostname, it is possibly wrong."
+    "240", "SSH setup is not valid. Please follow the instructions and check your application ini file."
+    "239", "Fatal error during SSH setup. Please contact us in this case."
+    
+    "100", "Someone uses a wrong exit code somewhere in Roddy. Exit codes should be in class ExitReasons (if possible) and must be in the range [1;255]."
+
+In any case, we try to provide you a good explanation about what happened wrong and how you can solve it. If you find
+the messages hard to understand, contact us.


### PR DESCRIPTION
This commit needs a fresh version of BatchEuphoria with the fixed JobManager issues!

Added the "integer" type to RoddyAppConfig class. We might think of reusing similar code from ConfigurationValue.

Removed the tryInitialize.waitFor() from ExecutionService. It was either used wrong or not used at all. Made tryInitialize() work.

SSHExecutionService:
- Added another catch block for failed connection attempts. It will catch  unknown host exceptions.
- Changed exit codes to 255, 1 is more for failed submission items.
- Added two additional log messages for SSH.

Roddy / Constants
- Added the jobManagerUpdateInterval constant.
- Corrected the Job manager initialization in Roddy so that the new constant is used and the jobManager is created with the update interval setting.
- Corrected the waitForJobs() method and the exit(int) method.