### PR TITLE
Fix regression related not-quoting bash/map variables provided as arg…

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.groovy
@@ -57,12 +57,21 @@ enum AvailableFeatureToggles {
      * declare -x BASH_ARRAY="value"
      *
      * unless they are already quoted.
+     *
+     * You should turn this on if you use old Bash versions (at least before Bash 4.2, maybe also later). Some
+     * Bash versions do not import array variables that are explicitly exported in the calling context.
+     * This option simply exports array variables as strings. You can then cast them into array variables
+     * with e.g.
+     *
+     * declare -a varName="$importedVarName"
+     *
      */
     AutoQuoteBashArrayVariables(true),
 
     /**
      * Fail, if strict mode is enabled and auto filenames would be created.
      */
+    // TODO Make this the default in version 4
     FailOnAutoFilenames(false),
 
     /**

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
@@ -404,7 +404,7 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
     }
 
     private List<String> _bashArrayToStringList() {
-        String vTemp = value.trim().substring(1, value.length() - 2).trim() //Split away () and leading or trailing white characters.
+        String vTemp = value.trim()[1 .. -3].trim() //Split away () and leading or trailing white characters.
         String[] temp = vTemp.split(SPLIT_WHITESPACE) //Split by white character
 
         //Ignore leading and trailing brackets

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.groovy
@@ -404,7 +404,7 @@ class ConfigurationValue implements RecursiveOverridableMapContainer.Identifiabl
     }
 
     private List<String> _bashArrayToStringList() {
-        String vTemp = value.substring(1, value.length() - 2).trim() //Split away () and leading or trailing white characters.
+        String vTemp = value.trim().substring(1, value.length() - 2).trim() //Split away () and leading or trailing white characters.
         String[] temp = vTemp.split(SPLIT_WHITESPACE) //Split by white character
 
         //Ignore leading and trailing brackets

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -239,9 +239,9 @@ class BashConverter extends ConfigurationConverter {
     /** Dependent on the settings and whether the string is quoted, return the quoted string. */
     static String addQuotesIfRequested(String value, Boolean doQuote = true) {
         if (isQuoted(value) || !doQuote)
-            return value
+            value
         else
-            return '"' + value + '"'
+            '"' + value + '"'
     }
 
     static String convertListToBashArrayString(List list, doQuote = true) {

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -18,7 +18,7 @@ import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import groovy.transform.CompileStatic
 
 import java.util.logging.Level
-import static Constants.RODDY_CONFIGURATION_MAGICSTRING
+import static de.dkfz.roddy.Constants.RODDY_CONFIGURATION_MAGICSTRING
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_BASH_ARRAY
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_DOUBLE
 import static de.dkfz.roddy.config.ConfigurationConstants.CVALUE_TYPE_FLOAT
@@ -35,7 +35,6 @@ class BashConverter extends ConfigurationConverter {
 
     final String separator = Constants.ENV_LINESEPARATOR
 
-    //TODO Use a pipeline converter interface with methods like "convertCValues, convertCValueBundles, convertTools"
     @Override
     String convert(ExecutionContext context, Configuration _cfg) {
         Configuration cfg = new Configuration(null, _cfg)
@@ -245,12 +244,20 @@ class BashConverter extends ConfigurationConverter {
             return '"' + value + '"'
     }
 
-    static String convertListToBashArrayString(List list) {
-        "(${list.collect { it.toString() }.join(" ")})" as String
+    static String convertListToBashArrayString(List list, doQuote = true) {
+        String result = "(${list.collect { it.toString() }.join(" ")})"
+        if (doQuote)
+            '"' + result + '"'
+        else
+            result
     }
 
-    static String convertMapToBashMapString(Map map) {
-        "(${map.collect { k, v -> "[$k]=$v"}.join(" ")})" as String
+    static String convertMapToBashMapString(Map map, doQuote = true) {
+        String result = "(${map.collect { k, v -> "[$k]=$v" }.join(" ")})"
+        if (doQuote)
+            '"' + result + '"'
+        else
+            result
     }
 
     /** To convert a simple Map of String keys to String values (possibly pre-converted!), this method should be used.

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -337,7 +337,8 @@ class Job extends BEJob<BEJob, BEJobResult> {
             } else
                 convertedParameters.add(o.toString())
         }
-        return BashConverter.convertListToBashArrayString(convertedParameters)
+        return BashConverter.convertListToBashArrayString(convertedParameters,
+            context.getFeatureToggleStatus(AvailableFeatureToggles.AutoQuoteBashArrayVariables))
     }
 
 

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
@@ -6,6 +6,7 @@
 
 package de.dkfz.roddy.knowledge.methods
 
+import de.dkfz.roddy.AvailableFeatureToggles
 import de.dkfz.roddy.config.*
 import de.dkfz.roddy.config.converters.BashConverter
 import de.dkfz.roddy.core.ExecutionContext
@@ -285,9 +286,13 @@ class GenericMethod {
             } else if (entry instanceof Map) {
                 (entry as Map).forEach { k, v ->
                     if (v instanceof List)
-                        parameters[k.toString()] = BashConverter.convertListToBashArrayString(v)
+                        parameters[k.toString()] =
+                                BashConverter.convertListToBashArrayString(v,
+                                        context.getFeatureToggleStatus(AvailableFeatureToggles.AutoQuoteBashArrayVariables))
                     else if (v instanceof Map)
-                        parameters[k.toString()] = BashConverter.convertMapToBashMapString(v)
+                        parameters[k.toString()] =
+                                BashConverter.convertMapToBashMapString(v,
+                                    context.getFeatureToggleStatus(AvailableFeatureToggles.AutoQuoteBashArrayVariables))
                     else
                         parameters[k.toString()] = v.toString()
                 }

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.sh
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.sh
@@ -35,7 +35,6 @@ declare -x    XMLValidation=true
 declare -x    ForbidSubmissionOnRunning=true
 declare -x    BreakSubmissionOnError=true
 declare -x    RollbackOnSubmissionOnError=false
-declare -x    ModifiedVariablePassing=true
 declare -x    UseOldDataSetIDExtraction=true
 declare -x    AutoFilenames=false
 declare -x    UnzipZippedPlugins=false

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131318173_heinold_test/runtimeConfig.xml
@@ -32,7 +32,6 @@
     <cvalue name='ForbidSubmissionOnRunning' value='true' />
     <cvalue name='BreakSubmissionOnError' value='true' />
     <cvalue name='RollbackOnSubmissionOnError' value='false' />
-    <cvalue name='ModifiedVariablePassing' value='true' />
     <cvalue name='UseOldDataSetIDExtraction' value='true' />
     <cvalue name='AutoFilenames' value='false' />
     <cvalue name='UnzipZippedPlugins' value='false' />

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.sh
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.sh
@@ -35,7 +35,6 @@ declare -x    XMLValidation=true
 declare -x    ForbidSubmissionOnRunning=true
 declare -x    BreakSubmissionOnError=true
 declare -x    RollbackOnSubmissionOnError=false
-declare -x    ModifiedVariablePassing=true
 declare -x    UseOldDataSetIDExtraction=true
 declare -x    AutoFilenames=false
 declare -x    UnzipZippedPlugins=false

--- a/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
+++ b/RoddyCore/test/resources/exampleProject/project/queryExtendedDataSetInfo/roddyExecutionStore/exec_160919_131518173_heinold_test/runtimeConfig.xml
@@ -32,7 +32,6 @@
     <cvalue name='ForbidSubmissionOnRunning' value='true' />
     <cvalue name='BreakSubmissionOnError' value='true' />
     <cvalue name='RollbackOnSubmissionOnError' value='false' />
-    <cvalue name='ModifiedVariablePassing' value='true' />
     <cvalue name='UseOldDataSetIDExtraction' value='true' />
     <cvalue name='AutoFilenames' value='false' />
     <cvalue name='UnzipZippedPlugins' value='false' />


### PR DESCRIPTION
…uments to Job-constructor.

In-line parameters of job-calls are maps and were not correctly mapped to quoted string in parameter file resulting in not exporting them into the Bash scripts (due to bash bug).