### PR TITLE
Changes for API-breaking BE update. Reimplementation of some ExecutionServices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,22 +82,50 @@ jobs: # a collection of steps
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ghr -t "$GITHUB_TOKEN" -u "$CIRCLE_PROJECT_USERNAME" -r "$CIRCLE_PROJECT_REPONAME" -c "$CIRCLE_SHA1" -delete "$CIRCLE_TAG" ./gradleBuilds/distributions/*.zip
+            # Retrieve version
+            VERSION=$(ls ./gradleBuild/distributions/Roddy-*.zip | sed -r 's/.*Roddy-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?).zip/\1/')
+            
+            # Ensure buildversion.txt is up to date
+            buildVersionTxt=$(cat RoddyCore/buildversion.txt | tr '\n' '.' | sed -r s/\.$//)
+            if [[ "$VERSION" != "$buildVersionTxt" ]]; then
+              echo "buildversion.txt not updated" >> /dev/stderr
+              exit 1
+            fi
+            
+            # Do the actual release
+            ghr -t "$GITHUB_TOKEN" -u "$CIRCLE_PROJECT_USERNAME" -r "$CIRCLE_PROJECT_REPONAME" -c "$CIRCLE_SHA1" -n "$VERSION" "$VERSION" ./gradleBuilds/distributions/*.zip
 
 workflows:
   version: 2
-  workflow:
+  build:
     jobs:
       - pre-build
       - build-and-test:
           requires:
             - pre-build
+  release:
+    jobs:
+      - pre-build:
+          filters:
+            branches: # ignore any commit on any branch by default
+              ignore: /.*/
+            tags: # unless they match the pattern
+              only: /^\d+\.\d+\.\d+$/
+      - build-and-test:
+          requires:
+            - pre-build
+          filters:
+            branches:  # ignore any commit on any branch by default
+              ignore: /.*/
+            tags:  # unless they match the pattern
+              only: /^\d+\.\d+\.\d+$/
       - publish-github-release:
+          context:
+            - TheRoddyWMS
           requires:
             - build-and-test
-          filters:  # Only publish for proper version tags on the master branch.
-            branches:
-              only: master
-            tags:
+          filters:
+            branches:  # ignore any commit on any branch by default
+              ignore: /.*/
+            tags:  # unless they match the pattern
               only: /^\d+\.\d+\.\d+$/
-

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -8,8 +8,11 @@
   - patch: Bugfix: Failure to pass the job resuming step (e.g. via `bresume`), with jobs that cannot be resumed (e.g. submitted via the DirectExecutionJobManager, like in the Bam2FastqPlugin).
     
   - patch: The command in `roddyCall.sh` is properly escaped and suited for direct copy-paste to the command-line
-    
+  
+  - patch: Bugfix: Did not handle subsequent variable references in cvalue validation correctly.
+  
   - patch: Better error reporting for submission errors
+  
   - patch: Bumped BatchEuphoria to 0.0.13
     
   - patch: Bumped RoddyToolLib to 2.3.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/TheRoddyWMS/Roddy.svg?branch=master)](https://travis-ci.com/TheRoddyWMS/Roddy) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FTheRoddyWMS%2FRoddy.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FTheRoddyWMS%2FRoddy?ref=badge_shield)
+[![CircleCI](https://circleci.com/gh/TheRoddyWMS/Roddy/tree/master.svg?style=svg)](https://circleci.com/gh/TheRoddyWMS/Roddy/tree/master) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FTheRoddyWMS%2FRoddy.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FTheRoddyWMS%2FRoddy?ref=badge_shield)
 
 # What is Roddy? 
 

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationIssue.groovy
@@ -52,10 +52,10 @@ class ConfigurationIssue {
                 "Variables in your configuration mismatch regarding their type and value. See the extended logs for more information.",
                 "The value of variable named '#REPLACE_0#' defined in '#REPLACE_1#' is not of its declared type '#REPLACE_2#'."
         ),
-        inproperVariableExpression(
+        malformedVariableExpression(
                 ConfigurationIssueLevel.CVALUE_WARNING,
                 "Variables in your configuration appear to misuse variable references. For variable references \${variable identifier} nesting like '\${\${innerVar}}' is forbidden and it must not be empty.",
-                "Variable '#REPLACE_0#' defined in '#REPLACE_1#' may use malformatted variable references. For variables references like \${variable identifier} nesting like '\${\${innerVar}}' is forbidden and it must not be empty."
+                "Variable '#REPLACE_0#' defined in '#REPLACE_1#' may use malformed variable references. For variables references like \${variable identifier} nesting like '\${\${innerVar}}' is forbidden and it must not be empty."
         )
 
         final ConfigurationIssueLevel level

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/DefaultValidator.groovy
@@ -100,7 +100,7 @@ class DefaultValidator extends ConfigurationValueValidator {
         return result
     }
 
-    static final String VARIABLE = '([^\\\\{][$][{]([\\w[-]_]){1,}[}])|(^[$][{]([\\w[-]_]){1,}[}])'
+    static final String VARIABLE = '(^|(?<=[^\\\\{]))[$][{]([\\w[-]_]){1,}[}]'
     static final String VARIABLE_START = '([^\\\\|^{][$][{])|(^[$][{])'
 
     boolean areVariablesProperlyDefined(ConfigurationValue cv) {
@@ -115,7 +115,7 @@ class DefaultValidator extends ConfigurationValueValidator {
         boolean result = countOfVariables == countOfStartedVariables
 
         if (!result) {
-            super.warnings << new ConfigurationIssue(inproperVariableExpression, cv.id, cv?.configuration?.file?.toString())
+            super.warnings << new ConfigurationIssue(malformedVariableExpression, cv.id, cv?.configuration?.file?.toString())
         }
 
         return result

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
@@ -542,7 +542,7 @@ class ExecutionContext {
 
                 def state = rj.jobState
                 if (state.plannedOrRunning) {
-                    if (state.running)
+                    if (state.runningOrStarted)
                         return true
                     else {
                         //Check previous jobs... Or just wait for the next step???

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/NoNoExecutionService.groovy
@@ -8,11 +8,8 @@ package de.dkfz.roddy.execution.io
 
 import groovy.transform.CompileStatic
 
-import java.io.File
-import java.io.OutputStream
-import java.io.Serializable
-import java.util.LinkedList
-import java.util.List
+import java.time.Duration
+
 /**
  * A dummy execution service which returns empty things and positive results.
  */
@@ -23,7 +20,9 @@ class NoNoExecutionService extends ExecutionService {
     }
 
     @Override
-    protected ExecutionResult _execute(String command, boolean waitFor, boolean ignoreErrors, OutputStream outputStream) {
+    protected ExecutionResult _execute(String command, boolean waitFor,
+                                       Duration timeout = Duration.ZERO,
+                                       OutputStream outputStream) {
         return new ExecutionResult([command], true, 0,
                 new LinkedList<>(), new LinkedList<>(), "")
     }

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -395,9 +395,6 @@ class SSHExecutionService extends RemoteExecutionService {
         CompletableFuture<Tuple3<Integer,List<String>, List<String>>> processF = CompletableFuture.supplyAsync({
             SSHPoolConnectionSet connectionSet = waitForService()
             SSHClient sshClient = connectionSet.client
-
-            // Append a newgrp (Philip: better "newgrp -"!) to each command, so that all
-            // command context in the proper group context.
             connectionSet.acquire()
             Session session = sshClient.startSession()
             List<String> stdout

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -437,7 +437,7 @@ class SSHExecutionService extends RemoteExecutionService {
             processF.thenApply { it.z as List<String> })
 
         if (waitFor) {
-            return result.asExecutionResult()
+            return result.asSynchronousExecutionResult()
         } else {
             return result
         }

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/fs/FileSystemAccessProvider.groovy
@@ -163,7 +163,7 @@ class FileSystemAccessProvider {
     }
 
     private boolean runFileTestCommand(String cmd) {
-        ExecutionResult er = ExecutionService.instance.execute(cmd, true, false)
+        ExecutionResult er = ExecutionService.instance.execute(cmd, true)
         return er.firstStdoutLine == commandSet.getReadabilityTestPositiveResult()
     }
 
@@ -186,7 +186,7 @@ class FileSystemAccessProvider {
 
     Long fileSize(File f) {
         def res = ExecutionService.instance.execute(
-                commandSet.getFileSizeCommand(f), true, true)
+                commandSet.getFileSizeCommand(f), true)
         if (res.successful)
             return Long.parseLong(res.firstStdoutLine)
         else
@@ -233,7 +233,7 @@ class FileSystemAccessProvider {
             else
                 return eService.execute(
                         commandSet.getExecutabilityTestCommand(f),
-                        true, true).
+                        true).
                         firstStdoutLine == commandSet.getReadabilityTestPositiveResult()
         }
     }
@@ -251,7 +251,7 @@ class FileSystemAccessProvider {
         if (!ExecutionService.instance.canListFiles()) {
             String cmd = commandSet.getListDirectoriesInDirectoryCommand(f, filters)
             ExecutionResult er =
-                    ExecutionService.instance.execute(cmd, true, false)
+                    ExecutionService.instance.execute(cmd, true)
             res = er.stdout
             res.each({ String folder -> folders.add(new File(folder)) })
         } else {
@@ -294,7 +294,7 @@ class FileSystemAccessProvider {
             else {
                 List<File> files = [];
                 String cmd = commandSet.getListFilesInDirectoryCommand(f, filters)
-                ExecutionResult er = eService.execute(cmd, true, false)
+                ExecutionResult er = eService.execute(cmd, true)
                 if (er.successful) {
                     for (String l : er.stdout) {
                         files << new File(l)
@@ -310,7 +310,7 @@ class FileSystemAccessProvider {
     List<File> listFilesUsingWildcards(File baseFolder, String wildcards) {
         ExecutionResult result = ExecutionService.instance.
                 execute(commandSet.getFindFilesUsingWildcardsCommand(baseFolder, wildcards),
-                        true, false)
+                        true)
         result.stdout.collect {
             new File(it)
         } as List<File>
@@ -329,7 +329,7 @@ class FileSystemAccessProvider {
         ExecutionResult result = ExecutionService.instance.
                 execute(commandSet.getListFullDirectoryContentRecursivelyCommand(
                         baseFolder, -1, FileType.FILES, false),
-                        true, false)
+                        true)
 
         List<File> foundFiles = result.stdout.collect { new File(it) } as List<File>
 
@@ -386,7 +386,7 @@ class FileSystemAccessProvider {
         } else {
             cmd = commandSet.getCheckDirectoryCommand(f)
         }
-        ExecutionResult er = ExecutionService.instance.execute(cmd, true, false)
+        ExecutionResult er = ExecutionService.instance.execute(cmd, true)
         return (er.firstStdoutLine == commandSet.readabilityTestPositiveResult)
     }
 
@@ -437,7 +437,7 @@ class FileSystemAccessProvider {
                 _userHome = new File(jHomeVar)
             } else {
                 String cmd = commandSet.userDirectoryCommand
-                ExecutionResult er = eService.execute(cmd, true, false)
+                ExecutionResult er = eService.execute(cmd, true)
                 _userHome = new File(er.firstStdoutLine)
             }
         }
@@ -447,7 +447,7 @@ class FileSystemAccessProvider {
     private String getSingleCommandValueOnValueIsNull(String _value, String command, String cacheEventID) {
         if (_value == null) {
             ExecutionResult er = ExecutionService.instance.
-                    execute(command, true, false)
+                    execute(command, true)
             _value = er.firstStdoutLine
         }
         return _value
@@ -473,7 +473,7 @@ class FileSystemAccessProvider {
         // Result could be a single line or several lines. So just combine and split again. This way, we are safe.
         new ComplexLine(ExecutionService.instance.
                 execute(commandSet.listOfGroupsCommand,
-                        true, false).stdout.join(' ')).splitBy(' ') as List<String>
+                        true).stdout.join(' ')).splitBy(' ') as List<String>
     }
 
     String getMyGroup() {
@@ -489,8 +489,7 @@ class FileSystemAccessProvider {
         synchronized (_groupIDsByGroup) {
             if (!_groupIDsByGroup.containsKey(groupID)) {
                 ExecutionResult er = ExecutionService.instance.
-                        execute(commandSet.getGroupIDCommand(groupID),
-                                true, false)
+                        execute(commandSet.getGroupIDCommand(groupID), true)
                 _groupIDsByGroup[groupID] = er.firstStdoutLine.toInteger()
             }
 
@@ -504,7 +503,7 @@ class FileSystemAccessProvider {
 
     private String _getOwnerOfPath(File file) {
         String cmd = commandSet.getOwnerOfPathCommand(file)
-        ExecutionResult er = ExecutionService.instance.execute(cmd, true, false)
+        ExecutionResult er = ExecutionService.instance.execute(cmd, true)
         return er.firstStdoutLine
     }
 
@@ -566,8 +565,7 @@ class FileSystemAccessProvider {
         if (eService.canCopyFiles()) {
             return eService.copyFile(_in, _out)
         } else {
-            return eService.execute(commandSet.getCopyFileCommand(_in, _out),
-                    true, false)
+            return eService.execute(commandSet.getCopyFileCommand(_in, _out), true)
         }
     }
 
@@ -580,8 +578,7 @@ class FileSystemAccessProvider {
         if (eService.canCopyFiles()) {
             return eService.moveFile(_from, _to);
         } else {
-            return eService.execute(commandSet.getMoveFileCommand(_from, _to),
-                    true, false);
+            return eService.execute(commandSet.getMoveFileCommand(_from, _to), true);
         }
     }
 
@@ -594,8 +591,7 @@ class FileSystemAccessProvider {
         if (eService.canCopyFiles()) {
             return eService.copyDirectory(_in, _out)
         } else {
-            def executionResult = eService.execute(commandSet.getCopyDirectoryCommand(_in, _out),
-                    true, false)
+            def executionResult = eService.execute(commandSet.getCopyDirectoryCommand(_in, _out), true)
             return executionResult.successful
         }
 
@@ -618,7 +614,7 @@ class FileSystemAccessProvider {
 
         ExecutionService eService = ExecutionService.instance
         String command = commandSet.getCheckChangeOfPermissionsPossibilityCommand(outputDirectory, myGroup)
-        def executionResult = eService.execute(command, true, false)
+        def executionResult = eService.execute(command, true)
         return executionResult.successful &&
                 executionResult.firstStdoutLine &&
                 executionResult.firstStdoutLine == BashCommandSet.TRUE
@@ -648,7 +644,7 @@ class FileSystemAccessProvider {
      */
     boolean setAccessRightsRecursively(File path, String accessStringDirectories, String accessStringFiles, String group) {
         commandSet.getSetAccessRightsRecursivelyCommand(path, accessStringDirectories, accessStringFiles, group)
-                .map { ExecutionService.instance.execute(it, false, false).successful }
+                .map { ExecutionService.instance.execute(it, false).successful }
                 .orElse(true)
     }
 
@@ -675,7 +671,7 @@ class FileSystemAccessProvider {
             return eService.modifyAccessRights(file, accessString, group)
         } else {
             return commandSet.getSetAccessRightsCommand(file, accessString, group)
-                    .map { eService.execute(it, true, false).successful }
+                    .map { eService.execute(it, true).successful }
                     .orElse(true)
         }
     }
@@ -708,7 +704,7 @@ class FileSystemAccessProvider {
                 return file.readLines().toArray(new String[0])
             } else {
                 return eService.execute(commandSet.
-                        getReadOutTextFileCommand(file), true, false).
+                        getReadOutTextFileCommand(file), true).
                         stdout.toArray(new String[0])
             }
         } catch (Exception ex) {
@@ -804,7 +800,7 @@ class FileSystemAccessProvider {
         if (eService.canDeleteFiles()) {
             return eService.removeDirectory(directory)
         } else {
-            return eService.execute(commandSet.getRemoveDirectoryCommand(directory), true, false)
+            return eService.execute(commandSet.getRemoveDirectoryCommand(directory), true)
         }
     }
 
@@ -824,7 +820,7 @@ class FileSystemAccessProvider {
         if (!_default_umask) {
             String command = commandSet.getUsermaskCommand
             ExecutionResult executionResult =
-                    ExecutionService.instance.execute(command, true, false)
+                    ExecutionService.instance.execute(command, true)
             _default_umask = Integer.decode(executionResult.firstStdoutLine)
         }
         return _default_umask

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/nativeworkflows/NativeWorkflow.groovy
@@ -139,7 +139,7 @@ class NativeWorkflow extends Workflow {
         System.out.println(finalCommand)
 
         ExecutionResult execute = ExecutionService.instance.
-                execute(finalCommand, true, false)
+                execute(finalCommand, true)
         logger.rare(execute.stdout.join("\n"))
         return true
     }

--- a/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/client/rmiclient/RoddyRMIInterfaceImplementationTest.groovy
@@ -19,8 +19,9 @@ import groovy.transform.CompileStatic
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.ClassRule
-import org.junit.Rule;
 import org.junit.Test
+
+import java.time.Duration
 
 /**
  * Test class with integration tests for the RMI interface.
@@ -45,8 +46,9 @@ public class RoddyRMIInterfaceImplementationTest {
         }
 
         @Override
-        protected ExecutionResult _execute(String command, boolean waitFor, boolean ignoreErrors, OutputStream outputStream) {
-            ExecutionResult list = super._execute(command, waitFor, ignoreErrors, outputStream);
+        protected ExecutionResult _execute(String command, boolean waitFor,
+                                           Duration timeout, OutputStream outputStream) {
+            ExecutionResult list = super._execute(command, waitFor, timeout, outputStream);
             executedCommands << command;
             return list;
         }

--- a/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/config/validation/DefaultValidatorSpec.groovy
@@ -97,9 +97,14 @@ class DefaultValidatorSpec extends RoddyTestSpec {
         'abc${var}v${var}' | CVALUE_TYPE_STRING | true     | []                                         | []
         '\\${c}'           | CVALUE_TYPE_STRING | true     | []                                         | []
         '\\${c'            | CVALUE_TYPE_STRING | true     | []                                         | []
-        'abc${${var}}'     | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla', 'null')] | []
-        'abc${'            | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla', 'null')] | []
-        'ab${c'            | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla', 'null')] | []
-        '${}'              | CVALUE_TYPE_STRING | false    | [inproperVariableExpression.expand('bla', 'null')] | []
+        '${a}'             | CVALUE_TYPE_STRING | true     | []                                         | []
+        '${a}  ${b}'       | CVALUE_TYPE_STRING | true     | []                                         | []
+        '\\${a}${b}'       | CVALUE_TYPE_STRING | true     | []                                         | []
+        '${a}\\${b}'       | CVALUE_TYPE_STRING | true     | []                                         | []
+        '${a}${b}'         | CVALUE_TYPE_STRING | true     | []                                         | []
+        'abc${${var}}'     | CVALUE_TYPE_STRING | false    | [malformedVariableExpression.expand('bla', 'null')] | []
+        'abc${'            | CVALUE_TYPE_STRING | false    | [malformedVariableExpression.expand('bla', 'null')] | []
+        'ab${c'            | CVALUE_TYPE_STRING | false    | [malformedVariableExpression.expand('bla', 'null')] | []
+        '${}'              | CVALUE_TYPE_STRING | false    | [malformedVariableExpression.expand('bla', 'null')] | []
     }
 }

--- a/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/ContextResource.groovy
@@ -20,9 +20,10 @@ import org.junit.rules.ExternalResource
 import org.junit.rules.TemporaryFolder
 
 import java.nio.file.Paths
+import java.time.Duration
 import java.util.concurrent.TimeoutException
 
-@groovy.transform.CompileStatic
+@CompileStatic
 class TestWorkflow extends Workflow {
 
     @Override
@@ -193,7 +194,8 @@ class ContextResource extends ExternalResource {
             }
 
             @Override
-            protected Map<BEJobID, JobState> queryJobStates(List list) {
+            protected Map<BEJobID, JobState> queryJobStates(List list,
+                                                            Duration timeout = Duration.ZERO) {
                 return null
             }
 
@@ -250,7 +252,8 @@ class ContextResource extends ExternalResource {
             }
 
             @Override
-            Map<BEJobID, GenericJobInfo> queryExtendedJobStateById(List list) {
+            Map<BEJobID, GenericJobInfo> queryExtendedJobStateById(List list,
+                                                                   Duration timeout = Duration.ZERO) {
                 return null
             }
 

--- a/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/core/MockupExecutionContextBuilder.groovy
@@ -14,6 +14,7 @@ import de.dkfz.roddy.execution.jobs.*
 import de.dkfz.roddy.knowledge.files.BaseFile
 import groovy.transform.CompileStatic
 
+import java.time.Duration
 import java.util.concurrent.TimeoutException
 
 /**
@@ -156,7 +157,8 @@ public class MockupExecutionContextBuilder {
             }
 
             @Override
-            protected Map<BEJobID, JobState> queryJobStates(List list) {
+            protected Map<BEJobID, JobState> queryJobStates(List list,
+                                                            Duration timeout = Duration.ZERO) {
                 return null
             }
 
@@ -213,7 +215,8 @@ public class MockupExecutionContextBuilder {
             }
 
             @Override
-            Map<BEJobID, GenericJobInfo> queryExtendedJobStateById(List list) {
+            Map<BEJobID, GenericJobInfo> queryExtendedJobStateById(List list,
+                                                                   Duration timeout = Duration.ZERO) {
                 return null
             }
 

--- a/RoddyCore/test/src/de/dkfz/roddy/execution/io/LocalExecutionServiceSpec.groovy
+++ b/RoddyCore/test/src/de/dkfz/roddy/execution/io/LocalExecutionServiceSpec.groovy
@@ -5,6 +5,9 @@ import de.dkfz.roddy.core.ContextResource
 import org.junit.Rule
 import spock.lang.Specification
 
+import java.time.Duration
+import java.util.concurrent.TimeoutException
+
 class LocalExecutionServiceSpec extends Specification {
 
     @Rule
@@ -83,5 +86,30 @@ class LocalExecutionServiceSpec extends Specification {
         res.stderr.size() == 1
         res.resultLines.size() == 1
     }
+
+    def "execute synchronously and run into timeout to get RuntimeException(cause=TimeoutException)"() {
+        when:
+        ExecutionResult res = es.execute("sleep 10; echo 'error' >> /dev/stderr; true",
+                true, new Duration(1, 0))
+
+        then:
+        def e = thrown(RuntimeException)
+        e.cause instanceof TimeoutException
+    }
+
+    def "execute asynchronously and run into timeout to get RuntimeException(cause=TimeoutException)"() {
+        given:
+        ExecutionResult res = es.execute("sleep 10; echo 'error' >> /dev/stderr; true",
+                false, new Duration(1, 0))
+
+        when:
+        res.exitCode
+
+        then:
+        def e = thrown(RuntimeException)
+        e.cause instanceof TimeoutException
+    }
+
+
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,8 @@ repositories {
     maven { url "https://repo1.maven.org/maven2/" }       // Some of the remaining dependencies
 }
 
-ext.roddyToolLibVersion = "2.3.0"
-ext.batchEuphoriaVersion = "0.0.13"
+ext.roddyToolLibVersion = "2.4.0"
+ext.batchEuphoriaVersion = "0.1.0"
 
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor(0, 'seconds')

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ repositories {
 }
 
 ext.roddyToolLibVersion = "2.4.0"
-ext.batchEuphoriaVersion = "0.1.0"
+ext.batchEuphoriaVersion = "0.0.14"
 
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor(0, 'seconds')

--- a/dist/bin/develop/helperScripts/findPluginLibraries.groovy
+++ b/dist/bin/develop/helperScripts/findPluginLibraries.groovy
@@ -1,4 +1,5 @@
 import java.nio.file.AccessDeniedException
+import java.nio.file.Paths
 
 /*
  * Copyright (c) 2016 eilslabs.
@@ -8,24 +9,24 @@ import java.nio.file.AccessDeniedException
 
 
 List<String> parsePluginDirectoriesParameter(String roddyDirectory, String parameterValue) {
-	// Note: The plugins in the dist/plugins directory will be found first!
-	List<String> pluginLines = ["${roddyDirectory}/dist/plugins"] // Add the Roddy directory
-	pluginLines.addAll(parameterValue.split("[=]")[1].split("[,:]")) // Add lines from ini file
-	return pluginLines.unique().findAll { it != "" } // Filter the list to get rid of doublettes.
+    // Note: The plugins in the dist/plugins directory will be found first!
+    List<String> pluginLines = ["${roddyDirectory}/dist/plugins"] // Add the Roddy directory
+    pluginLines.addAll(parameterValue.split("[=]")[1].split("[,:]")) // Add lines from ini file
+    return pluginLines.unique().findAll { it != "" } // Filter the list to get rid of doublettes.
 }
 
 List<String> extractDependenciesFromBuildinfoFile(String pluginDir) {
-	File pluginPath = new File(pluginDir)
-	if (!pluginPath.canExecute())
-		throw new FileNotFoundException("Cannot access directory ${pluginPath.absolutePath}")
-	File buildInfo = new File(pluginPath, "buildinfo.txt")
-	if (!buildInfo.canRead())
-		throw new AccessDeniedException("Cannot access '${buildInfo.absolutePath}'")
-	return (buildInfo).
-			readLines().
-			findAll {
-				it.startsWith("dependson")
-			}.collect { it.split("[=]")[1] }
+    File pluginPath = new File(pluginDir)
+    if (!pluginPath.canExecute())
+        throw new FileNotFoundException("Cannot access directory ${pluginPath.absolutePath}")
+    File buildInfo = new File(pluginPath, "buildinfo.txt")
+    if (!buildInfo.canRead())
+        throw new AccessDeniedException("Cannot access '${buildInfo.absolutePath}'")
+    return (buildInfo).
+            readLines().
+            findAll {
+                it.startsWith("dependson")
+            }.collect { it.split("[=]")[1] }
 }
 
 /** Given a plugin name with version, if the version is not 'develop' then the plugin JAR may be called $id_$version.jar or $id.jar. If both are
@@ -35,46 +36,48 @@ List<String> extractDependenciesFromBuildinfoFile(String pluginDir) {
  *  'develop'.
  */
 List<File> findPossibleJarsForDependency(List<String> pluginDirectories, String pluginNameAndVersion) {
-	String pluginDirname = pluginNameAndVersion.replace(":", "_")
-	def (id, version) = pluginNameAndVersion.split("[:]")
-	pluginDirname = pluginDirname.replace("_develop", "")
+    String pluginDirname = pluginNameAndVersion.replace(":", "_")
+    def (id, version) = pluginNameAndVersion.split("[:]")
+    pluginDirname = pluginDirname.replace("_develop", "")
 
-	return pluginDirectories.collect { String pluginsDir ->
-		def searchPath = new File(pluginsDir, pluginDirname)
-		def jar = new File(searchPath, "${id}.jar")
-		def versionedJar = new File(searchPath, "${id}_${version}.jar")
-		if (version != "develop") {
-			if (jar.canRead() && versionedJar.canRead())  {
-				System.err.println("WARNING: Directory '${searchPath.absolutePath}' contains two the readable JARs '${jar.name}' and '${versionedJar.name}'. Using versioned JAR.")
-				[versionedJar]
-			} else if (jar.canRead()) {
-				[jar]
-			} else if (versionedJar.canRead()) {
-				[versionedJar]
-			} else {
-				[]
-			}
-		} else
-			[jar]
-	}.flatten()
+    return pluginDirectories.collect { String pluginsDir ->
+        def searchPath = new File(pluginsDir, pluginDirname)
+        def jar = new File(searchPath, "${id}.jar")
+        def versionedJar = new File(searchPath, "${id}_${version}.jar")
+        if (version != "develop") {
+            if (jar.canRead() && versionedJar.canRead())  {
+                System.err.println("WARNING: Directory '${searchPath.absolutePath}' contains two the readable JARs '${jar.name}' and '${versionedJar.name}'. Using versioned JAR.")
+                [versionedJar]
+            } else if (jar.canRead()) {
+                [jar]
+            } else if (versionedJar.canRead()) {
+                [versionedJar]
+            } else {
+                System.err.println("INFO: Candidate JAR not found or not readable: $jar")
+                []
+            }
+        } else
+            [jar]
+    }.flatten()
 }
 
 List<File> findPossibleJarsForDependencies(List<String> pluginDirectories, List<String> pluginsAndVersions) {
-	return pluginsAndVersions.collect { findPossibleJarsForDependency(pluginDirectories, it) }.flatten()
+    return pluginsAndVersions.collect { findPossibleJarsForDependency(pluginDirectories, it) }.flatten()
 }
 
 List<File> collectAllJars(List<String> pluginSearchDirectories, String pluginDirectory) {
-	List<String> dependencies = extractDependenciesFromBuildinfoFile(pluginDirectory)
-	List<File> possibleJars = findPossibleJarsForDependencies(pluginSearchDirectories, dependencies)
-
-	def jars = possibleJars.findAll() { it.exists()  }
-
-	// Now search recursively for the dependencies of the newly found JARs.
-	return jars.collect {
-		it.parent.toString()
-	}.collect {
-		jars + collectAllJars(pluginSearchDirectories, it)
-	}.flatten().unique()
+    List<String> dependencies = extractDependenciesFromBuildinfoFile(pluginDirectory)
+    List<File> possibleJars = findPossibleJarsForDependencies(pluginSearchDirectories, dependencies)
+    def jars = possibleJars.findAll() { it.exists()  }
+    if (jars.size() == 0) {
+        System.err.println("Did not find any JAR for dependencies: $dependencies from $pluginDirectory")
+    }
+    // Now search recursively for the dependencies of the newly found JARs.
+    return jars.collect {
+        it.parent.toString()
+    }.collect {
+        jars + collectAllJars(pluginSearchDirectories, it)
+    }.flatten().unique()
 }
 
 
@@ -87,17 +90,17 @@ List<File> collectAllJars(List<String> pluginSearchDirectories, String pluginDir
 // - The working directory for the query plugin
 
 if (args.size() != 3) {
-	System.err.println('Given a list of pluginDirectories (search paths), a roddyDirectory, and a queryPluginDirectory to find all plugin jars in the plugins dependencies.')
-	System.err.println('Usage: findPluginLibraries pluginDirectories=pluginDirectoryA,pluginDirectoryB roddyDirectory/ queryPluginDirectory/')
-	System.exit(1)
+    System.err.println('Given a list of pluginDirectories (search paths), a roddyDirectory, and a queryPluginDirectory to find all plugin jars in the plugins dependencies.')
+    System.err.println('Usage: findPluginLibraries pluginDirectories=pluginDirectoryA,pluginDirectoryB roddyDirectory/ queryPluginDirectory/')
+    System.exit(1)
 }
 def pluginDirectoryParameter = args[0]
 def roddyDirectory = args[1]
 def queryPluginDirectory = args[2]
 
 if (!pluginDirectoryParameter.startsWith("pluginDirectories=")) {
-	System.err.println("First parameter should start with 'pluginDirectories='")
-	System.exit(1)
+    System.err.println("First parameter should start with 'pluginDirectories='")
+    System.exit(1)
 }
 
 List<String> pluginDirectories = parsePluginDirectoriesParameter(roddyDirectory, pluginDirectoryParameter)


### PR DESCRIPTION
* patch: Removed redundant implementation of LocalExecutionService (now calling RoddyToolLib code)
* patch: Added timeout arguments to ExecutionService.execute method calls, defaulting to Duration.ZERO (= no timeout)
* patch: SSHExecutionService now uses CompletableFutures for execution thus allowing for asynchronous execution.
* patch: JobState.STARTED considered as kind of running.
* patch: removed dysfunctional `ignoreErrors` from Roddy's ExecutionService implementation. Error are not ignored thus, but by catching and handling exceptions.

Note that the implementation of the SSHExecutionService timeout is a workaround using the Linux command `timeout`. The reason is that there is a version conflict for SSHJ caused by the JSCH agent-proxy command. SSHJ and JSCH libraries could eventually be replaced by something else, e.g. mina-ssh.